### PR TITLE
Class function handler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
       - run:
           name: Running tests
           command: make test-ci
+      - store_test_results:
+          path: /tmp/test-results
       - run:
           name: Running checks
           command: make check

--- a/eventsourcing_helpers/command_handler.py
+++ b/eventsourcing_helpers/command_handler.py
@@ -13,8 +13,8 @@ class CommandHandler:
     """
     Command handler.
 
-    Handles a command by calling the correct function or method
-    in a handler class.
+    Handles a command by calling the correct function or method in a handler
+    class.
     """
     handlers: dict = {}
 
@@ -39,12 +39,12 @@ class CommandHandler:
 
         return True
 
-    def _handle_command(self, command: Any, handler_class: Any = None) -> None:
+    def _handle_command(self, command: Any, handler_class: Any=None) -> None:
         """
         Get and call the correct command handler.
 
-        The handler can either be a callable or a name of a method
-        in the handler class.
+        The handler can either be a callable or a name of a method in the
+        handler class.
 
         Args:
             command: Command to be handled.
@@ -76,9 +76,11 @@ class ESCommandHandler(CommandHandler):
     """
     Event sourced command handler.
 
-    Unlike the command handler we expect an aggregate root to handle all
-    the commands. The resulting staged events are published to a message
-    bus and persisted in an event store using a repository.
+    Unlike the command handler we expect an aggregate root to handle all the
+    commands.
+
+    The resulting staged events are published to a message bus and persisted in
+    an event store using a repository.
     """
     aggregate_root: AggregateRoot = None
     repository_config: dict = None
@@ -108,8 +110,7 @@ class ESCommandHandler(CommandHandler):
 
     def _get_aggregate_root(self, guid: str) -> AggregateRoot:
         """
-        Get latest state of the aggregate root or return an
-        empty instance.
+        Get latest state of the aggregate root or return an empty instance.
 
         Args:
             guid: Guid of the aggregate root.
@@ -136,8 +137,8 @@ class ESCommandHandler(CommandHandler):
         """
         Apply correct handler for the received command.
 
-        After the command has been handled the staged
-        events are committed to the repository.
+        After the command has been handled the staged events are committed to
+        the repository.
 
         Args:
             message: Consumed message from the bus.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 [[ -z "${VIRTUAL_ENV}" ]] && . .venv/bin/activate
-pytest -s --cov=eventsourcing_helpers/
+pytest -s --cov=eventsourcing_helpers/ --junitxml=/tmp/test-results/report.xml
 
 if [ "$1" == "ci" ]; then
     codecov -t $CODECOV_TOKEN

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -25,6 +25,7 @@ class ESCommandHandlerTests:
 
     def setup_method(self):
         self.aggregate_root = Mock()
+        self.aggregate_root.foo_method = Mock()
 
         config = {'return_value.load.return_value': events}
         self.repository = Mock()
@@ -57,7 +58,7 @@ class ESCommandHandlerTests:
         mock_can_handle.assert_called_once_with(message)
         mock_get.assert_called_once_with(command.guid)
         mock_handle.assert_called_once_with(
-            command, handler_class=self.aggregate_root
+            command, handler_inst=self.aggregate_root
         )
         mock_commit.assert_called_once_with(self.aggregate_root)
 
@@ -70,11 +71,19 @@ class ESCommandHandlerTests:
             self.aggregate_root
         )
 
-    def test_handle_command(self):
+    def test_handle_command_by_str(self):
         """
-        Test that the correct command handler is invoked.
+        Test that the correct command handler is invoked using a str.
         """
-        self.handler._handle_command(command, handler_class=self.aggregate_root)
+        self.handler._handle_command(command, handler_inst=self.aggregate_root)
+        self.aggregate_root.foo_method.called_once_with(command)
+
+    def test_handle_command_by_function(self):
+        """
+        Test that the correct command handler is invoked using a function.
+        """
+        self.handler.handlers = {command_class: self.aggregate_root.foo_method}
+        self.handler._handle_command(command, handler_inst=self.aggregate_root)
         self.aggregate_root.foo_method.called_once_with(command)
 
     @patch(f'{module}.ESCommandHandler._get_events')
@@ -127,7 +136,6 @@ class CommandHandlerTests:
         Test that the correct methods are invoked when handling a command.
         """
         mock_can_handle.return_value = True
-
         self.handler.handle(message)
 
         message_deserializer.assert_called_once_with(message)

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -80,7 +80,7 @@ class ESCommandHandlerTests:
 
     def test_handle_command_by_function(self):
         """
-        Test that the correct command handler is invoked using a function.
+        Test that the correct command handler is invoked using a class function.
         """
         self.handler.handlers = {command_class: self.aggregate_root.foo_method}
         self.handler._handle_command(command, handler_inst=self.aggregate_root)


### PR DESCRIPTION
Make it possible to use a class function as a handler instead of using a string. Example:

Before:
```python
class OrderCommandHandler(ESCommandHandler):
    aggregate_root = Order
    handlers = {
        'AddArticleToOrder': 'add_article'
    }    
```
After:
```python
class OrderCommandHandler(ESCommandHandler):
    aggregate_root = Order
    handlers = {
        'AddArticleToOrder': Order.add_article,
    }    
```