### PR TITLE
Implement the equal method to messages

### DIFF
--- a/eventsourcing_helpers/message.py
+++ b/eventsourcing_helpers/message.py
@@ -15,6 +15,9 @@ class Message:
         filtered = {k: v for k, v in items if v is not None}
         return filtered
 
+    def __eq__(self, other) -> bool:
+        return self.__dict__ == other.__dict__
+
     def __repr__(self) -> str:
         return repr(self.message)
 


### PR DESCRIPTION
We need to be able to compare two messages if they have the same data, they are equal. 
It's easier to test if the right message was produced when we have the `equal` method implemented.