### PR TITLE
changed required version of confluent-kafka-helpers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pytest-mock
 pytest-sugar
 structlog
 
-git+https://github.com/fyndiq/confluent_kafka_helpers@v0.4.1#egg=confluent-kafka-helpers
+git+https://github.com/fyndiq/confluent_kafka_helpers@v0.5.2#egg=confluent-kafka-helpers

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name="eventsourcing-helpers",
-      version="0.6.1",
+      version="0.6.2",
       description="Helpers for practicing the Event sourcing pattern",
       url="https://github.com/fyndiq/eventsourcing_helpers",
       author="Fyndiq AB",
@@ -11,9 +11,9 @@ setup(name="eventsourcing-helpers",
       install_requires=[
           'structlog>=17.2.0',
           'cnamedtuple>=0.1.6',
-          'confluent-kafka-helpers==0.5.1',
+          'confluent-kafka-helpers==0.5.2',
       ],
       dependency_links=[
-          'git+https://github.com/fyndiq/confluent_kafka_helpers@v0.5.1#egg=confluent-kafka-helpers-0.5.1'
+          'git+https://github.com/fyndiq/confluent_kafka_helpers@v0.5.2#egg=confluent-kafka-helpers-0.5.2'
       ],
       zip_safe=False)


### PR DESCRIPTION
Use newer tag for confluent-kafka-helpers. Depends on new tag which will be created after https://github.com/fyndiq/confluent_kafka_helpers/pull/20 is merged