### PR TITLE
Handle AttributeError's

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,13 @@ jobs:
           paths:
             - ".venv"
       - run:
+          name: Running lint
+          command: make lint
+      - run:
           name: Running tests
           command: make test-ci
       - store_test_results:
           path: /tmp/test-results
-      - run:
-          name: Running checks
-          command: make check
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ setup:
 lint:
 	./scripts/lint.sh
 
-test:
+test: lint
 	./scripts/test.sh
 
 test-ci:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 setup:
 	./scripts/setup.sh
 
-check:
-	./scripts/check.sh
+lint:
+	./scripts/lint.sh
 
 test:
 	./scripts/test.sh

--- a/eventsourcing_helpers/command_handler.py
+++ b/eventsourcing_helpers/command_handler.py
@@ -109,7 +109,7 @@ class ESCommandHandler(CommandHandler):
         """
         with self.repository.load(id) as events:
             for event in events:
-                yield self.message_deserializer(event)
+                yield self.message_deserializer(event, is_new=False)
 
     def _get_aggregate_root(self, id: str) -> AggregateRoot:
         """

--- a/eventsourcing_helpers/consumer.py
+++ b/eventsourcing_helpers/consumer.py
@@ -1,6 +1,5 @@
-from eventsourcing_helpers.messagebus import MessageBus
-
 from eventsourcing_helpers.handler import Handler
+from eventsourcing_helpers.messagebus import MessageBus
 
 
 class Consumer:

--- a/eventsourcing_helpers/handler.py
+++ b/eventsourcing_helpers/handler.py
@@ -18,4 +18,6 @@ class Handler:
         Args:
             message: Consumed message from the bus.
         """
-        raise NotImplementedError("You need to implement handle method in your subclass")
+        raise NotImplementedError(
+            "You need to implement handle method in your subclass"
+        )

--- a/eventsourcing_helpers/message.py
+++ b/eventsourcing_helpers/message.py
@@ -11,11 +11,11 @@ class Message:
     message class.
     """
     def __init__(self, **kwargs) -> None:
-        self.__dict__['_wrapped'] = self._wrapped(**kwargs)
+        self.__dict__['_wrapped'] = self._wrapped(**kwargs)  # type: ignore
 
     @property
     def _class(self) -> str:
-        return self._wrapped.__class__.__name__
+        return self._wrapped.__class__.__name__  # type: ignore
 
     def to_dict(self) -> dict:
         items = self._wrapped._asdict().items()  # type: ignore
@@ -26,7 +26,7 @@ class Message:
         return self.__dict__ == other.__dict__
 
     def __repr__(self) -> str:
-        return repr(self._wrapped)
+        return repr(self._wrapped)  # type: ignore
 
     def __setattr__(self, *args) -> None:
         raise AttributeError("Messages are read only")

--- a/eventsourcing_helpers/message.py
+++ b/eventsourcing_helpers/message.py
@@ -7,10 +7,17 @@ class Message:
     """
     Message proxy class.
 
-    Adds some extra features and redirects all attribute lookups to the wrapped
-    message class.
+    Wraps a message class to provide some extra features.
+
+    All attribute lookups are redirected to the wrapped message class.
     """
+
     def __init__(self, **kwargs) -> None:
+        # At this point the instance variable `self._wrapped` is already set.
+        #
+        # The reason we are saving it in `self.__dict__` is to skip hitting the
+        # `__setattr__`dunder method - and thus getting the "Messages are read
+        # only" error.
         self.__dict__['_wrapped'] = self._wrapped(**kwargs)  # type: ignore
 
     @property
@@ -19,8 +26,8 @@ class Message:
 
     def to_dict(self) -> dict:
         items = self._wrapped._asdict().items()  # type: ignore
-        filtered = {k: v for k, v in items if v is not None}
-        return filtered
+        items = {k: v for k, v in items if v is not None}
+        return items
 
     def __eq__(self, other) -> bool:
         return self.__dict__ == other.__dict__
@@ -31,6 +38,10 @@ class Message:
     def __setattr__(self, *args) -> None:
         raise AttributeError("Messages are read only")
 
+    def __getattr__(self, name: str) -> Callable:
+        # redirects all attribute lookups to the real message class.
+        raise NotImplementedError
+
 
 class NewMessage(Message):
     """
@@ -39,6 +50,7 @@ class NewMessage(Message):
     If we try to access an attribute that doesn't exist we should raise an
     AttributeError.
     """
+
     def __getattr__(self, name: str) -> Callable:
         return getattr(self._wrapped, name)
 
@@ -53,6 +65,7 @@ class OldMessage(Message):
     Otherwise we would have to implement try/catch logic in our apply methods
     when we add new fields to our Avro schemas.
     """
+
     def __getattr__(self, name: str) -> Callable:
         return getattr(self._wrapped, name, None)
 
@@ -82,7 +95,7 @@ def message_factory(message_cls: namedtuple, is_new=True) -> type:
         Message: Message proxy.
 
     Example:
-        >>> @Event
+        >>> @message_factory
         ... class OrderCreated(NamedTuple):
         ...     id: str
         ...     state: str
@@ -94,13 +107,19 @@ def message_factory(message_cls: namedtuple, is_new=True) -> type:
         >>> isinstance(event, Message)
         True
     """
+    # Dynamically create a new class with the same name as the message
+    # (event/command) we are wrapping.
+    #
+    # The new class will inherit from `proxy_cls` and `object` with one
+    # instance variable set `_wrapped` which is the actual message
+    # (event/command) being wrapped.
     proxy_cls = NewMessage if is_new else OldMessage
     proxy = type(
-        message_cls.__name__, (proxy_cls, object),
-        {'_wrapped': message_cls}
+        message_cls.__name__, (proxy_cls, object), {'_wrapped': message_cls}
     )
     return proxy
 
 
+# Make the names more explicit for which type of message we are dealing with.
 Event = lambda message: message_factory(message)
 Command = lambda message: message_factory(message)

--- a/eventsourcing_helpers/messagebus/__init__.py
+++ b/eventsourcing_helpers/messagebus/__init__.py
@@ -21,7 +21,8 @@ class MessageBus:
     DEFAULT_BACKEND = 'kafka_avro'
 
     def __init__(self, config: dict,
-                 importer: Callable=import_backend) -> None:  # yapf: disable
+                 importer: Callable=import_backend,
+                 **kwargs) -> None:  # yapf: disable
         backend_path = config.get('backend', BACKENDS[self.DEFAULT_BACKEND])
         assert 'backend_config' in config, "You must pass a backend config"
         backend_config = config.get('backend_config')
@@ -29,7 +30,7 @@ class MessageBus:
         logger.debug("Using message bus backend", backend=backend_path,
                      config=backend_config)
         backend_class = importer(backend_path)
-        self.backend = backend_class(backend_config)
+        self.backend = backend_class(backend_config, **kwargs)
 
     def produce(self, value, key=None, **kwargs):
         """

--- a/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
@@ -11,20 +11,21 @@ from confluent_kafka_helpers.producer import AvroProducer
 from eventsourcing_helpers import metrics
 from eventsourcing_helpers.messagebus.backends import MessageBusBackend
 from eventsourcing_helpers.messagebus.backends.kafka.config import (
-    get_consumer_config, get_producer_config)
+    get_consumer_config, get_producer_config
+)
 from eventsourcing_helpers.serializers import to_message_from_dto
 
 logger = structlog.get_logger(__name__)
 
 
 class KafkaAvroBackend(MessageBusBackend):
-
-    def __init__(self, config: dict,
-                 producer: AvroProducer=AvroProducer,
-                 consumer: AvroConsumer=AvroConsumer,
-                 value_serializer: Callable=to_message_from_dto,
-                 get_producer_config: Callable=get_producer_config,
-                 get_consumer_config: Callable=get_consumer_config) -> None:  # yapf: disable
+    def __init__(
+        self, config: dict, producer: AvroProducer = AvroProducer,
+        consumer: AvroConsumer = AvroConsumer,
+        value_serializer: Callable = to_message_from_dto,
+        get_producer_config: Callable = get_producer_config,
+        get_consumer_config: Callable = get_consumer_config
+    ) -> None:
         self.consumer, self.producer = None, None
 
         producer_config = get_producer_config(config)
@@ -40,8 +41,9 @@ class KafkaAvroBackend(MessageBusBackend):
 
     @metrics.call_counter('eventsourcing_helpers.messagebus.kafka.handle.count')
     @metrics.statsd.timed('eventsourcing_helpers.messagebus.kafka.handle.time')
-    def _handle(self, handler: Callable, message: Message,
-                consumer: AvroConsumer) -> None:  # yapf: disable
+    def _handle(
+        self, handler: Callable, message: Message, consumer: AvroConsumer
+    ) -> None:
         start_time = time.time()
         handler(message)
         if consumer.is_auto_commit is False:
@@ -49,8 +51,9 @@ class KafkaAvroBackend(MessageBusBackend):
         end_time = time.time() - start_time
         logger.debug(f"Message processed in {end_time:.5f}s")
 
-    def produce(self, value: dict, key: str=None, topic: str=None,
-                **kwargs) -> None:  # yapf:disable
+    def produce(
+        self, value: dict, key: str = None, topic: str = None, **kwargs
+    ) -> None:
         assert self.producer is not None, "Producer is not configured"
 
         self.producer.produce(key=key, value=value, topic=topic, **kwargs)

--- a/eventsourcing_helpers/repository/backends/kafka/__init__.py
+++ b/eventsourcing_helpers/repository/backends/kafka/__init__.py
@@ -5,17 +5,18 @@ from confluent_kafka_helpers.producer import AvroProducer
 
 from eventsourcing_helpers.repository.backends import RepositoryBackend
 from eventsourcing_helpers.repository.backends.kafka.config import (
-    get_loader_config, get_producer_config)
+    get_loader_config, get_producer_config
+)
 from eventsourcing_helpers.serializers import to_message_from_dto
 
 
 class KafkaAvroBackend(RepositoryBackend):
-
-    def __init__(self, config: dict, producer=AvroProducer,
-                 loader=AvroMessageLoader,
-                 value_serializer: Callable=to_message_from_dto,
-                 get_producer_config: Callable=get_producer_config,
-                 get_loader_config: Callable=get_loader_config) -> None:  # yapf: disable
+    def __init__(
+        self, config: dict, producer=AvroProducer, loader=AvroMessageLoader,
+        value_serializer: Callable = to_message_from_dto,
+        get_producer_config: Callable = get_producer_config,
+        get_loader_config: Callable = get_loader_config
+    ) -> None:
         producer_config = get_producer_config(config)
         loader_config = get_loader_config(config)
 

--- a/eventsourcing_helpers/serializers.py
+++ b/eventsourcing_helpers/serializers.py
@@ -4,15 +4,18 @@ from eventsourcing_helpers.message import Message, message_factory
 from confluent_kafka_helpers.message import Message as ConfluentMessage
 
 
-def from_message_to_dto(message: ConfluentMessage) -> Message:
+def from_message_to_dto(message: ConfluentMessage, is_new=True) -> Message:
     """
     Deserialize a message to a data transfer object (DTO).
 
-    The message is just a dict expected to include a 'class' and 'data'
-    attribute. The class defines the type of the DTO and data the attributes.
+    The message is just a dict expected to include the keys 'class' and 'data'.
+
+    The class defines the type of the DTO and data the attributes.
 
     Args:
         message: Message to deserialize.
+        is_new: Flag that indicates if the message is new or loaded
+            from the repository.
 
     Returns:
         Message: DTO instance of type 'class' hydrated with 'data'.
@@ -31,8 +34,8 @@ def from_message_to_dto(message: ConfluentMessage) -> Message:
     data, class_name = message.value['data'], message.value['class']
     data['meta'] = message._meta
 
-    cls = namedtuple(class_name, data.keys())
-    dto = message_factory(cls)(**data)
+    message_cls = namedtuple(class_name, data.keys())
+    dto = message_factory(message_cls, is_new=is_new)(**data)
 
     return dto
 

--- a/eventsourcing_helpers/serializers.py
+++ b/eventsourcing_helpers/serializers.py
@@ -1,7 +1,8 @@
 from cnamedtuple import namedtuple
 
-from eventsourcing_helpers.message import Message, message_factory
 from confluent_kafka_helpers.message import Message as ConfluentMessage
+
+from eventsourcing_helpers.message import Message, message_factory
 
 
 def from_message_to_dto(message: ConfluentMessage, is_new=True) -> Message:

--- a/eventsourcing_helpers/utils.py
+++ b/eventsourcing_helpers/utils.py
@@ -17,7 +17,7 @@ def import_backend(location: str) -> Any:
         >>> import_backend(
             'eventsourcing_helpers.repository.backends.kafka.KafkaAvroBackend'
         )
-        <class 'eventsourcing_helpers.repository.backends.kafka.KafkaAvroBackend'>
+        <class 'eventsourcing_helpers.repository.backends.kafka.KafkaAvroBackend'>  # noqa
     """
     module_name, class_name = location.rsplit('.', 1)
     module = import_module(f'{module_name}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-codecov
 cnamedtuple
+codecov
+flake8
 ipdb
 mypy
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,15 @@
 cnamedtuple
 codecov
 flake8
+flake8-isort
 ipdb
+isort
 mypy
 pytest
 pytest-coverage
 pytest-mock
 pytest-sugar
 structlog
+yapf
 
 git+https://github.com/fyndiq/confluent_kafka_helpers@v0.5.2#egg=confluent-kafka-helpers

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-[[ -z "${VIRTUAL_ENV}" ]] && . .venv/bin/activate
-mypy eventsourcing_helpers/ --ignore-missing-imports --show-error-context

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+[[ -z "${VIRTUAL_ENV}" ]] && . .venv/bin/activate
+
+command -v flake8 >/dev/null 2>&1 || echo "flake8 is required"
+command -v mypy >/dev/null 2>&1 || echo "mypy is required"
+
+echo "Running flake8..."
+flake8
+
+echo "Running mypy..."
+mypy eventsourcing_helpers/

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,26 @@ omit =
 [mypy]
 ignore_missing_imports = True
 show_error_context = True
+
+[yapf]
+based_on_style = pep8
+column_limit = 80
+allow_split_before_dict_value = False
+blank_line_before_nested_class_or_def = False
+coalesce_brackets = False
+dedent_closing_brackets = True
+each_dict_entry_on_separate_line = False
+split_before_named_assigns = False
+split_complex_comprehension = True
+
+[isort]
+atomic=True
+line_length=80
+multi_line_output=5
+balanced_wrapping=True
+use_parentheses=True
+known_confluent=confluent_kafka_helpers
+known_localfolder=eventsourcing_helpers
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,CONFLUENT,LOCALFOLDER
+not_skip=__init__.py
+virtual_env=.venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,26 @@ python_functions=test_*
 python_classes = *Tests
 norecursedirs = .venv .git
 addopts = -vv
+
+[flake8]
+exclude =
+    .git,
+    .venv,
+    __pycache__,
+    requirements,
+    docs,
+    k8s,
+    scripts,
+    tests
+max-line-length = 80
+
+[coverage:run]
+branch = True
+omit =
+    .venv/*,
+    tests/*,
+    scripts
+
+[mypy]
+ignore_missing_imports = True
+show_error_context = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ exclude =
     k8s,
     scripts,
     tests
+ignore =
+    # lambda expressions
+    E731
 max-line-length = 80
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,21 @@
 from setuptools import setup, find_packages
 
-setup(name="eventsourcing-helpers",
-      version="0.6.2",
-      description="Helpers for practicing the Event sourcing pattern",
-      url="https://github.com/fyndiq/eventsourcing_helpers",
-      author="Fyndiq AB",
-      author_email="support@fyndiq.com",
-      license="MIT",
-      packages=find_packages(),
-      install_requires=[
-          'structlog>=17.2.0',
-          'cnamedtuple>=0.1.6',
-          'confluent-kafka-helpers==0.5.2',
-      ],
-      dependency_links=[
-          'git+https://github.com/fyndiq/confluent_kafka_helpers@v0.5.2#egg=confluent-kafka-helpers-0.5.2'
-      ],
-      zip_safe=False)
+setup(
+    name="eventsourcing-helpers",
+    version="0.6.2",
+    description="Helpers for practicing the Event sourcing pattern",
+    url="https://github.com/fyndiq/eventsourcing_helpers",
+    author="Fyndiq AB",
+    author_email="support@fyndiq.com",
+    license="MIT",
+    packages=find_packages(),
+    install_requires=[
+        'structlog>=17.2.0',
+        'cnamedtuple>=0.1.6',
+        'confluent-kafka-helpers==0.5.2'
+    ],
+    dependency_links=[
+        'git+https://github.com/fyndiq/confluent_kafka_helpers@v0.5.2#egg=confluent-kafka-helpers-0.5.2'  # noqa
+    ],
+    zip_safe=False
+)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -2,7 +2,7 @@ from typing import NamedTuple
 
 import pytest
 
-from eventsourcing_helpers.message import message_factory, Message
+from eventsourcing_helpers.message import Message, message_factory
 
 
 class MessageTests:
@@ -11,7 +11,8 @@ class MessageTests:
         self.data = {'id': 1, 'foo': 'bar', 'baz': None}
         fields = [(k, None) for k in self.data.keys()]
         self.namedtuple = NamedTuple('FooEvent', fields)
-        self.message = message_factory(self.namedtuple)(**self.data)
+        message_cls = message_factory(self.namedtuple, is_new=True)
+        self.message = message_cls(**self.data)
 
     def test_type(self):
         """
@@ -26,6 +27,15 @@ class MessageTests:
         """
         assert self.message.id == self.data['id']
         assert self.message.foo == self.data['foo']
+
+    def test_access_missing_attr_on_new_msg_should_raise_attribute_error(self):
+        with pytest.raises(AttributeError):
+            self.message.boo
+
+    def test_access_missing_attr_on_old_msg_should_return_none(self):
+        message_cls = message_factory(self.namedtuple, is_new=False)
+        message = message_cls(**self.data)
+        assert message.boo is None
 
     def test_to_dict(self):
         """


### PR DESCRIPTION
Right now our apply methods will raise an `AttributeError` on old messages when we are trying to access newly added fields in the Avro schemas (because they don't exist in the old messages).

So instead of adding try/catch logic in our apply methods we just return None on missing attributes for old messages.

`command_handler.py` and `message.py` are the important files, the rest is just other improvements because I'm lazy creating a separate branch :)  