### PR TITLE
Read-only messages for real

### DIFF
--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -8,7 +8,7 @@ from eventsourcing_helpers.message import Message, message_factory
 class MessageTests:
 
     def setup_method(self):
-        self.data = {'id': 1, 'foo': 'bar', 'baz': None}
+        self.data = {'id': 1, 'foo': 'bar', 'baz': None, 'foobar': {'a': 'b'}}
         fields = [(k, None) for k in self.data.keys()]
         self.namedtuple = NamedTuple('FooEvent', fields)
         message_cls = message_factory(self.namedtuple, is_new=True)
@@ -56,3 +56,16 @@ class MessageTests:
         """
         with pytest.raises(AttributeError):
             self.message.id = 2
+
+    def test_read_only_nested_data_type_new_message(self):
+        foobar = self.message.foobar
+        foobar['a'] = 'c'
+        assert self.message.foobar['a'] == 'b'
+
+    def test_read_only_nested_data_type_old_message(self):
+        message_cls = message_factory(self.namedtuple, is_new=False)
+        self.message = message_cls(**self.data)
+
+        foobar = self.message.foobar
+        foobar['a'] = 'c'
+        assert self.message.foobar['a'] == 'b'


### PR DESCRIPTION
Right now the top level attributes are read only (NamedTuple), but if the value is a mutable data structure it's still possible to accidentally change stuff in the messages. 