### PR TITLE
Configure Redis socket connect/read timeouts from config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flake8
 flake8-isort
 ipdb
 isort
-mypy
+mypy<0.600
 pytest
 pytest-coverage
 pytest-mock
@@ -12,7 +12,7 @@ pytest-sugar
 structlog
 yapf
 
-git+https://github.com/fyndiq/confluent_kafka_helpers@v0.5.2#egg=confluent-kafka-helpers
+git+https://github.com/fyndiq/confluent_kafka_helpers@confluent-kafka-python-v0.11.4#egg=confluent-kafka-helpers
 redis==2.10.6
 hiredis==0.2.0
 fakeredis==0.9.0


### PR DESCRIPTION
This pull requests allows configuring Redis socket/read timeouts for Double Reads Watchdog by specifying `socket_connect_timeout` and `socket_timeout` parameters in Redis backend config. Values are floats and specify seconds. If not specified, defaults (0.1s) are used.