### PR TITLE
Edit metrics

### DIFF
--- a/eventsourcing_helpers/command_handler.py
+++ b/eventsourcing_helpers/command_handler.py
@@ -4,8 +4,8 @@ import structlog
 
 from confluent_kafka_helpers.message import Message
 
-from eventsourcing_helpers import metrics
 from eventsourcing_helpers.handler import Handler
+from eventsourcing_helpers.metrics import statsd
 from eventsourcing_helpers.models import AggregateRoot
 from eventsourcing_helpers.repository import Repository
 from eventsourcing_helpers.serializers import from_message_to_dto
@@ -76,7 +76,7 @@ class CommandHandler(Handler):
         command_class = command._class
         handler = self.handlers[command_class]
         handler_name = get_callable_representation(handler)
-        with metrics.timed(
+        with statsd.timed(
             'eventsourcing_helpers.handler.handle',
             tags=[
                 'message_type:command',
@@ -152,7 +152,7 @@ class ESCommandHandler(CommandHandler):
         command_class = command._class
         handler = self.handlers[command_class]
         handler_name = get_callable_representation(handler)
-        with metrics.timed(
+        with statsd.timed(
             'eventsourcing_helpers.handler.handle',
             tags=[
                 'message_type:command',

--- a/eventsourcing_helpers/command_handler.py
+++ b/eventsourcing_helpers/command_handler.py
@@ -77,7 +77,7 @@ class CommandHandler(Handler):
         handler = self.handlers[command_class]
         handler_name = get_callable_representation(handler)
         with statsd.timed(
-            'eventsourcing_helpers.handler.handle',
+            'eventsourcing_helpers.handler.handle.time',
             tags=[
                 'message_type:command',
                 f'message_class:{command_class}',
@@ -153,7 +153,7 @@ class ESCommandHandler(CommandHandler):
         handler = self.handlers[command_class]
         handler_name = get_callable_representation(handler)
         with statsd.timed(
-            'eventsourcing_helpers.handler.handle',
+            'eventsourcing_helpers.handler.handle.time',
             tags=[
                 'message_type:command',
                 f'message_class:{command_class}',

--- a/eventsourcing_helpers/command_handler.py
+++ b/eventsourcing_helpers/command_handler.py
@@ -54,21 +54,11 @@ class CommandHandler(Handler):
         command_class = command._class
         handler = self.handlers[command_class]
 
-        handler_name = get_callable_representation(handler)
-        handler_wrapper = metrics.timed(
-            'eventsourcing_helpers.handler.handle',
-            tags=[
-                'message_type:command',
-                f'message_class:{command_class}',
-                f'handler:{handler_name}'
-            ]
-        )(handler)
-
         logger.info("Calling command handler", command_class=command_class)
         if handler_inst:
-            handler_wrapper(handler_inst, command)
+            handler(handler_inst, command)
         else:
-            handler_wrapper(command)
+            handler(command)
 
     def handle(self, message: dict) -> None:
         """
@@ -82,7 +72,19 @@ class CommandHandler(Handler):
 
         command = self.message_deserializer(message)
         logger.info("Handling command", command_class=command._class)
-        self._handle_command(command)
+
+        command_class = command._class
+        handler = self.handlers[command_class]
+        handler_name = get_callable_representation(handler)
+        with metrics.timed(
+            'eventsourcing_helpers.handler.handle',
+            tags=[
+                'message_type:command',
+                f'message_class:{command_class}',
+                f'handler:{handler_name}'
+            ]
+        ):
+            self._handle_command(command)
 
 
 class ESCommandHandler(CommandHandler):
@@ -147,6 +149,17 @@ class ESCommandHandler(CommandHandler):
         command = self.message_deserializer(message)
         logger.info("Handling command", command_class=command._class)
 
-        aggregate_root = self._get_aggregate_root(command.id)
-        self._handle_command(command, handler_inst=aggregate_root)
-        self._commit_staged_events(aggregate_root)
+        command_class = command._class
+        handler = self.handlers[command_class]
+        handler_name = get_callable_representation(handler)
+        with metrics.timed(
+            'eventsourcing_helpers.handler.handle',
+            tags=[
+                'message_type:command',
+                f'message_class:{command_class}',
+                f'handler:{handler_name}'
+            ]
+        ):
+            aggregate_root = self._get_aggregate_root(command.id)
+            self._handle_command(command, handler_inst=aggregate_root)
+            self._commit_staged_events(aggregate_root)

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -43,10 +43,15 @@ class ESCommandHandlerTests:
     @patch(f'{module}.ESCommandHandler._handle_command')
     @patch(f'{module}.ESCommandHandler._get_aggregate_root')
     @patch(f'{module}.ESCommandHandler._can_handle_command')
-    def test_handle(self, mock_can_handle, mock_get, mock_handle, mock_commit):
+    @patch(f'{module}.metrics.timed')
+    def test_handle(self, mock_metrics_timed, mock_can_handle,
+                    mock_get, mock_handle, mock_commit
+                    ):
         """
         Test that the correct methods are invoked when handling a command.
         """
+        mock_metrics_timed.return_value.__enter__.return_value = Mock
+
         mock_can_handle.return_value = True
         mock_get.return_value = self.aggregate_root
 
@@ -101,10 +106,13 @@ class CommandHandlerTests:
 
     @patch(f'{module}.CommandHandler._handle_command')
     @patch(f'{module}.CommandHandler._can_handle_command')
-    def test_handle(self, mock_can_handle, mock_handle):
+    @patch(f'{module}.metrics.timed')
+    def test_handle(self, mock_metrics_timed, mock_can_handle, mock_handle):
         """
         Test that the correct methods are invoked when handling a command.
         """
+        mock_metrics_timed.return_value.__enter__.return_value = Mock
+
         mock_can_handle.return_value = True
         self.handler.handle(message)
 
@@ -130,3 +138,4 @@ class CommandHandlerTests:
         """
         self.handler._handle_command(command)
         self.mock_handler.called_once_with(command)
+

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -43,7 +43,7 @@ class ESCommandHandlerTests:
     @patch(f'{module}.ESCommandHandler._handle_command')
     @patch(f'{module}.ESCommandHandler._get_aggregate_root')
     @patch(f'{module}.ESCommandHandler._can_handle_command')
-    @patch(f'{module}.metrics.timed')
+    @patch(f'{module}.statsd.timed')
     def test_handle(self, mock_metrics_timed, mock_can_handle,
                     mock_get, mock_handle, mock_commit
                     ):
@@ -106,7 +106,7 @@ class CommandHandlerTests:
 
     @patch(f'{module}.CommandHandler._handle_command')
     @patch(f'{module}.CommandHandler._can_handle_command')
-    @patch(f'{module}.metrics.timed')
+    @patch(f'{module}.statsd.timed')
     def test_handle(self, mock_metrics_timed, mock_can_handle, mock_handle):
         """
         Test that the correct methods are invoked when handling a command.


### PR DESCRIPTION
Right now the metrics of our eventsourced handlers does not include the time of reading up the aggregates, even though this is a significant part of the time needed to apply the event. 
In this PR i change the metrics so that this is included in the metrics