### PR TITLE
Remove .poll(0) call

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
@@ -80,7 +80,10 @@ class KafkaAvroBackend(MessageBusBackend):
         assert self.producer is not None, "Producer is not configured"
 
         self.producer.produce(key=key, value=value, topic=topic, **kwargs)
-        self.producer.poll(0)
+        if 'callback' in kwargs:
+            # The poll will ensure that the callback for the _previous_
+            # produce call gets called
+            self.producer.poll(0)
         if self.flush:
             self.producer.flush()
 


### PR DESCRIPTION
The .poll() method serves to ensure that the delivery callback function of the _previous_ .produce gets called. Since we do not supply a delivery callback function when calling .produce, the .poll() serves no purpose for our case. We've seen locally that the .poll() call can cause a lag, so removing it should yield a performance improvement