### PR TITLE
Add snapshot rollbacks on kafka commit failures

### DIFF
--- a/eventsourcing_helpers/repository/__init__.py
+++ b/eventsourcing_helpers/repository/__init__.py
@@ -72,7 +72,7 @@ class Repository:
                 logger.info("Kafka commit failed, rolling back snapshot!")
                 statsd.increment(
                     'eventsourcing_helpers.snapshot.cache.rollbacks',
-                    tags=[f'id={aggregate_root.id}']
+                    tags=[f'id={id}']
                 )
                 self.snapshot.rollback(aggregate_root)
                 raise e

--- a/eventsourcing_helpers/repository/snapshot/__init__.py
+++ b/eventsourcing_helpers/repository/snapshot/__init__.py
@@ -63,7 +63,7 @@ class Snapshot:
         Saves an aggregate to the snapshot storage
 
         Args:
-            aggregate_root (AggregateRoot): The aggregate to be saved
+            aggregate_root: The aggregate to be saved
         Returns:
             None
         """
@@ -86,7 +86,7 @@ class Snapshot:
         Args:
             id: ID of the aggregate root.
             Args:
-            aggregate_root (AggregateRoot): The aggregate type of the object
+            aggregate_root: The aggregate type of the object
                                             to load
 
         Returns:
@@ -98,3 +98,18 @@ class Snapshot:
         aggregate_root = self.deserializer(snapshot, current_hash)
 
         return aggregate_root
+
+    def rollback(self, aggregate_root: AggregateRoot) -> None:
+        """
+        Rolls back latest change in the snapshot storage.
+        If the last change cannot be "rolled back" then the entry must be
+        deleted. This will make us take the most recent data from the event
+        storage
+
+        Args:
+            aggregate_root: The aggregate to be rolled back
+
+        Returns:
+            None
+        """
+        self.backend.rollback(aggregate_root.id)

--- a/eventsourcing_helpers/repository/snapshot/backends/__init__.py
+++ b/eventsourcing_helpers/repository/snapshot/backends/__init__.py
@@ -9,3 +9,6 @@ class SnapshotBackend:
 
     def load(self, id: str) -> dict:
         raise NotImplementedError()
+
+    def rollback(self, id: str) -> None:
+        raise NotImplementedError()

--- a/eventsourcing_helpers/repository/snapshot/backends/mongo/__init__.py
+++ b/eventsourcing_helpers/repository/snapshot/backends/mongo/__init__.py
@@ -46,3 +46,15 @@ class MongoSnapshotBackend(SnapshotBackend):
             return snapshot_data
         except PyMongoError:
             return None
+
+    def rollback(self, id: str) -> None:
+        """
+        Rolls back the data of the snapshot with specified id.
+
+        Args:
+            id (str): The id to save the data for
+        Returns:
+            None
+        """
+        query = {'_id': id}
+        self.db.snapshots.delete_many(query)

--- a/eventsourcing_helpers/repository/snapshot/backends/null/__init__.py
+++ b/eventsourcing_helpers/repository/snapshot/backends/null/__init__.py
@@ -13,3 +13,6 @@ class NullSnapshotBackend(SnapshotBackend):
 
     def load(self, id: str) -> dict:
         return None
+
+    def rollback(self, id: str) -> None:
+        pass

--- a/tests/repository/snapshot/backends/mongo/test_backend.py
+++ b/tests/repository/snapshot/backends/mongo/test_backend.py
@@ -77,3 +77,17 @@ class MongoSnapshotBackendTests():
         self.backend = MongoSnapshotBackend(config, mongo_client_mock)
 
         mongo_client_mock.assert_called_once_with(**expected_call)
+
+    def test_mongo_rollback_deletes_latest_snapshot(self):
+        id = 'a'
+        query = {'_id': id}
+        data = {'b': 1}
+
+        db = self.backend.client.snapshots.snapshots
+        db.find_one_and_replace(
+            query, data, upsert=True
+        )
+        assert db.find().count() == 1
+
+        self.backend.rollback(id)
+        assert db.find().count() == 0

--- a/tests/repository/snapshot/test_snapshot.py
+++ b/tests/repository/snapshot/test_snapshot.py
@@ -53,3 +53,11 @@ class SnapshotTests:
         self.backend().load.assert_called_once_with(test_id)
         self.deserializer.assert_called_once_with(
             self.snapshot_data_mock, test_hash)
+
+    def test_rollback(self):
+        snapshot = self.snapshot()
+        aggregate_root = self.aggregate_root_cls()
+        aggregate_root.id = 1
+        snapshot.rollback(aggregate_root)
+
+        self.backend().rollback.assert_called_once_with(aggregate_root.id)


### PR DESCRIPTION
It's important that our aggregate in kafka and our snapshots always contain the same data. If we are unsure of what the data should be in the snapshots, then it's better to delete them.

It could happen that the snapshot storage is working but not kafka, in this case we cannot (!) update the snapshot!

It could also happen that kafka is working but not the snapshot storage. In this case we must crash, otherwise we will get a mismatch between the data in kafka compared to the snapshot.

See also https://fyndiq.atlassian.net/secure/RapidBoard.jspa?rapidView=95&projectKey=MP&modal=detail&selectedIssue=MP-168.