### PR TITLE
Always poll

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
@@ -86,10 +86,11 @@ class KafkaAvroBackend(MessageBusBackend):
         assert self.producer is not None, "Producer is not configured"
 
         self.producer.produce(key=key, value=value, topic=topic, **kwargs)
-        if 'callback' in kwargs:
-            # The poll will ensure that the callback for the _previous_
-            # produce call gets called
-            self.producer.poll(0)
+        self.producer.poll(0)
+        # if 'callback' in kwargs:
+        #     # The poll will ensure that the callback for the _previous_
+        #     # produce call gets called
+        #     self.producer.poll(0)
         if self.flush:
             self.producer.flush()
 

--- a/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
@@ -87,10 +87,6 @@ class KafkaAvroBackend(MessageBusBackend):
 
         self.producer.produce(key=key, value=value, topic=topic, **kwargs)
         self.producer.poll(0)
-        # if 'callback' in kwargs:
-        #     # The poll will ensure that the callback for the _previous_
-        #     # produce call gets called
-        #     self.producer.poll(0)
         if self.flush:
             self.producer.flush()
 


### PR DESCRIPTION
Sometimes we receive `BufferError: Local: Queue full` when producing. This might be due to the fact that we are not polling after each produce and thus not consuming the delivery reports - which might be the reason the buffer fills up.