### PR TITLE
Pass backend config as keyword argument.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ jobs:
       - image: fyndiq/python-alpine-kafka:latest
     steps:
       - checkout
-      - run:
-          name: Install virtualenv
-          command: pip install virtualenv
       - restore_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:

--- a/eventsourcing_helpers/messagebus/__init__.py
+++ b/eventsourcing_helpers/messagebus/__init__.py
@@ -32,7 +32,7 @@ class MessageBus:
             config=backend_config
         )
         backend_class = importer(backend_path)
-        self.backend = backend_class(backend_config, **kwargs)
+        self.backend = backend_class(config=backend_config, **kwargs)
 
     def produce(self, value, key=None, **kwargs):
         """

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,5 @@
-#!/usr/bin/env sh
-command -v virtualenv >/dev/null 2>&1 || echo "virtualenv is required"
-
-virtualenv -p python3 .venv
+#!/usr/bin/env bash
+set -e
+python3 -m venv .venv
 source .venv/bin/activate
-pip install --process-dependency-links --no-cache-dir -r requirements.txt
+pip install -r requirements.txt


### PR DESCRIPTION
## Changes
 - Pass backend config as keyword argument

This allows us to use `unittest.mock.MagicMock` as backend.

Right now the backend config is passed as the `spec` arg for the mock (https://docs.python.org/3/library/unittest.mock.html#the-mock-class)
(since we don't use kwargs) which will lead to unexpected behaviour.

For example if we want to mock Kafka in a service (running Dredd tests for example) we can do something like this:
```python
#!/usr/bin/env python3
from unittest.mock import patch

from app import init_app

KAFKA_MESSAGEBUS_CONFIG = {
    'backend': 'unittest.mock.MagicMock',
    'backend_config': {}
}
with patch('app.config.KAFKA_MESSAGEBUS_CONFIG', KAFKA_MESSAGEBUS_CONFIG):
    server = init_app()

if __name__ == '__main__':
    server.run(host='0.0.0.0', port=8000)
```
Right now this is not working since the `spec` will be set to mock a `dict`.