### PR TITLE
message: keep none values in to_dict method

### DIFF
--- a/eventsourcing_helpers/message.py
+++ b/eventsourcing_helpers/message.py
@@ -30,7 +30,7 @@ class Message:
 
     def to_dict(self) -> dict:
         items = self._wrapped._asdict().items()  # type: ignore
-        items = {k: v for k, v in items if v is not None}
+        items = {k: v for k, v in items}
         return items
 
     def __eq__(self, other) -> bool:

--- a/eventsourcing_helpers/message.py
+++ b/eventsourcing_helpers/message.py
@@ -29,9 +29,7 @@ class Message:
         return self._wrapped.__class__.__name__  # type: ignore
 
     def to_dict(self) -> dict:
-        items = self._wrapped._asdict().items()  # type: ignore
-        items = {k: v for k, v in items}
-        return items
+        return self._wrapped._asdict()
 
     def __eq__(self, other) -> bool:
         return self.__dict__ == other.__dict__

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -41,7 +41,6 @@ class MessageTests:
         """
         Test that the message is serialized correctly.
         """
-        self.data.pop('baz')
         assert self.message.to_dict() == self.data
 
     def test_name(self):


### PR DESCRIPTION
## Changes
 - Keep none values in `to_dict` method. 

## Rationale
Not sure why we initially decided to remove keys with none values. But the main reason keep them now to is to be consistent with the same data being accessible using attributes (`__getattr__`) and the data available in `to_dict`. Currently you can always access an attribute that exists in the schema and get the default value (usually None), where in `to_dict` we remove them. 

Currently we have an issue in `reclaimit-projection-builder-service` (https://sentry.io/organizations/fyndiq-global/issues/1625440384/?project=5175985&query=is%3Aunresolved) where we serialize the event using `to_dict` and assuming all keys exists.