### PR TITLE
Update Kafka config builders

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/kafka/config.py
+++ b/eventsourcing_helpers/messagebus/backends/kafka/config.py
@@ -1,6 +1,26 @@
 from collections import defaultdict
 from copy import deepcopy
 
+TOP_LEVEL_PRODUCER_CONFIG_KEYS = (
+    'bootstrap.servers',
+    'schema.registry.url',
+    'security.protocol',
+    'sasl.mechanisms',
+    'sasl.username',
+    'sasl.password',
+    'ssl.ca.location',
+)
+
+TOP_LEVEL_CONSUMER_CONFIG_KEYS = (
+    'bootstrap.servers',
+    'schema.registry.url',
+    'security.protocol',
+    'sasl.mechanisms',
+    'sasl.username',
+    'sasl.password',
+    'ssl.ca.location',
+)
+
 
 def get_producer_config(config):
     config = deepcopy(config)
@@ -8,10 +28,9 @@ def get_producer_config(config):
     if not producer_config or not producer_config.get('enabled', True):
         return None
 
-    producer_config.update({
-        'bootstrap.servers': config['bootstrap.servers'],
-        'schema.registry.url': config['schema.registry.url']
-    })
+    for key in TOP_LEVEL_PRODUCER_CONFIG_KEYS:
+        if key in config:
+            producer_config.update({f'{key}': config[key]})
     return producer_config
 
 
@@ -22,10 +41,9 @@ def get_consumer_config(config):
         return None
 
     consumer_config.pop('offset_watchdog', None)
-    consumer_config.update({
-        'bootstrap.servers': config['bootstrap.servers'],
-        'schema.registry.url': config['schema.registry.url']
-    })
+    for key in TOP_LEVEL_CONSUMER_CONFIG_KEYS:
+        if key in config:
+            consumer_config.update({f'{key}': config[key]})
     return consumer_config
 
 
@@ -35,10 +53,6 @@ def get_offset_watchdog_config(config):
     if not consumer_config:
         return None
 
-    offset_wd_config = defaultdict(
-        dict, consumer_config.get('offset_watchdog', {})
-    )
-    offset_wd_config['backend_config'].update(
-        {'group.id': consumer_config['group.id']}
-    )
+    offset_wd_config = defaultdict(dict, consumer_config.get('offset_watchdog', {}))
+    offset_wd_config['backend_config'].update({'group.id': consumer_config['group.id']})
     return offset_wd_config


### PR DESCRIPTION
## Changes
 - Define a list of top level config keys to use in the producer/consumer configs. Otherwise we must duplicate the keys in both the producer/consumer configs in the client.