### PR TITLE
Use deque instead of list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fyndiq/backend-developers

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ coverage.xml
 build/
 dist/
 .pytest_cache
-
+.eggs

--- a/eventsourcing_helpers/messagebus/backends/mock/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/__init__.py
@@ -30,10 +30,13 @@ class Consumer:
 
 @dataclass
 class Producer:
-    messages: List[dict] = field(default_factory=list)
+    messages: Deque[dict] = field(default_factory=deque)
 
     def add_message(self, message: dict) -> None:
         self.messages.append(message)
+
+    def clear_messages(self) -> None:
+        self.messages.clear()
 
     def assert_one_message_produced_with(self, key: str, value: dict) -> None:
         assert len(self.messages) == 1

--- a/eventsourcing_helpers/messagebus/backends/mock/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/__init__.py
@@ -1,5 +1,6 @@
+from collections import deque
 from dataclasses import dataclass, field
-from typing import Callable, List
+from typing import Callable, Deque
 
 import structlog
 
@@ -13,13 +14,13 @@ logger = structlog.get_logger(__name__)
 
 @dataclass
 class Consumer:
-    messages: List[Message] = field(default_factory=list)
+    messages: Deque[Message] = field(default_factory=deque)
 
     def add_message(self, message_class: str, data: dict) -> None:
         message = create_message(message_class=message_class, data=data)
         self.messages.append(message)
 
-    def get_messages(self) -> List[Message]:
+    def get_messages(self) -> Deque[Message]:
         return self.messages
 
     def assert_one_message_added_with(self, message_class: str, data: dict) -> None:
@@ -53,4 +54,4 @@ class MockBackend(MessageBusBackend):
     def consume(self, handler: Callable) -> None:
         messages = self.consumer.get_messages()
         while messages:
-            handler(messages.pop())
+            handler(messages.popleft())

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ addopts = -vv -p no:warnings
 exclude =
     .git,
     .venv,
+    .eggs,
     __pycache__,
     requirements,
     docs,


### PR DESCRIPTION
## Changes
 - Use `deque` instead of `list` so we can pop messages from left easily. Otherwise the messages will be processed in the wrong order when adding multiple messages
 - Add method `Producer.clear_messages`