### PR TITLE
Rename meta to Meta

### DIFF
--- a/eventsourcing_helpers/serializers.py
+++ b/eventsourcing_helpers/serializers.py
@@ -37,7 +37,7 @@ def from_message_to_dto(message: ConfluentKafkaMessage, is_new=True) -> Message:
         OrderCompleted(order_id='UA123', date='2017-09-08')
     """
     data, class_name = message.value['data'], message.value['class']
-    data['meta'] = message._meta
+    data['Meta'] = message._meta
 
     message_cls = namedtuple(class_name, data.keys())
     dto = message_factory(message_cls, is_new=is_new)(**data)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -23,7 +23,7 @@ class SerializerTests:
         from_message_to_dto(message)
 
         assert mock_factory.call_args[0][0].__name__ == 'FooClass'
-        assert mock_factory.call_args[0][0]._fields == ('foo', 'meta')
+        assert mock_factory.call_args[0][0]._fields == ('foo', 'Meta')
 
     def test_to_message_from_dto(self):
         """


### PR DESCRIPTION
## Changes
 - Rename `message.meta` to `message.Meta` so we don't conflict and override any existing field called `meta`