### PR TITLE
Don't pin required packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,18 @@ jobs:
       - restore_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
+          name: Install build tools
+          command: apt update && apt install -y gcc
+      - run:
           name: Install dependencies
           command: make setup
       - save_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:
             - ".venv"
+      - run:
+          name: Install package
+          command: pip install '.[mongo,redis,cnamedtuple]'
       - run:
           name: Running lint
           command: make lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: fyndiq/python-alpine-kafka:latest
+      - image: fyndiq/python-confluent-kafka:latest
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@
 [![license](https://img.shields.io/pypi/l/eventsourcing-helpers.svg)](https://pypi.org/project/eventsourcing-helpers/)
 
 A Python library for practicing the event sourcing pattern using DDD.
+
+## Installation
+
+    pip install .
+    pip install -r requirements.txt

--- a/eventsourcing_helpers/metrics.py
+++ b/eventsourcing_helpers/metrics.py
@@ -30,7 +30,7 @@ try:
     import datadog
     statsd = datadog.statsd
 except ModuleNotFoundError:
-    statsd = StatsdNullClient()
+    statsd = StatsdNullClient()  # type: ignore
 
 
 def call_counter(base_metric):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 codecov
+fakeredis
 flake8
 flake8-eradicate
 flake8-isort
@@ -12,13 +13,4 @@ pytest
 pytest-coverage
 pytest-mock
 pytest-sugar
-structlog
 yapf
-
-cnamedtuple
-confluent-kafka-helpers
-fakeredis
-hiredis
-jsonpickle
-pymongo
-redis

--- a/requirements.in
+++ b/requirements.in
@@ -1,16 +1,13 @@
-cnamedtuple
 codecov
 flake8
 flake8-eradicate
 flake8-isort
 ipdb
 isort
-jsonpickle
 mongomock
 mypy
 pdbpp
 pip-tools
-pymongo
 pytest
 pytest-coverage
 pytest-mock
@@ -18,7 +15,10 @@ pytest-sugar
 structlog
 yapf
 
-confluent-kafka-helpers==0.7.6
-redis==2.10.6
-hiredis==0.2.0
-fakeredis==0.9.0
+cnamedtuple
+confluent-kafka-helpers
+fakeredis
+hiredis
+jsonpickle
+pymongo
+redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,34 +5,26 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 attrs==20.2.0             # via flake8-eradicate, pytest
-avro-python3==1.10.0      # via confluent-kafka-helpers
 backcall==0.2.0           # via ipython
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via pip-tools
-cnamedtuple==0.1.6        # via -r requirements.in
 codecov==2.1.9            # via -r requirements.in
-confluent-kafka-helpers==0.7.7  # via -r requirements.in
-confluent-kafka==1.5.0    # via confluent-kafka-helpers
 coverage==5.3             # via codecov, pytest-cov
 decorator==4.4.2          # via ipython
 eradicate==1.0            # via flake8-eradicate
 fakeredis==1.4.3          # via -r requirements.in
 fancycompleter==0.9.1     # via pdbpp
-fastavro==1.0.0.post1     # via confluent-kafka-helpers
 flake8-eradicate==0.4.0   # via -r requirements.in
 flake8-isort==4.0.0       # via -r requirements.in
 flake8==3.8.3             # via -r requirements.in, flake8-eradicate, flake8-isort
-hiredis==1.1.0            # via -r requirements.in
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via jsonpickle
 iniconfig==1.0.1          # via pytest
 ipdb==0.13.3              # via -r requirements.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.18.1           # via ipdb
 isort==5.5.2              # via -r requirements.in, flake8-isort
 jedi==0.17.2              # via ipython
-jsonpickle==1.4.1         # via -r requirements.in
 mccabe==0.6.1             # via flake8
 mongomock==3.20.0         # via -r requirements.in
 more-itertools==8.5.0     # via pytest
@@ -51,7 +43,6 @@ py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
 pygments==2.7.0           # via ipython, pdbpp
-pymongo==3.11.0           # via -r requirements.in
 pyparsing==2.4.7          # via packaging
 pyrepl==0.9.0             # via fancycompleter
 pytest-cov==2.10.1        # via pytest-cover
@@ -60,12 +51,11 @@ pytest-coverage==0.0      # via -r requirements.in
 pytest-mock==3.3.1        # via -r requirements.in
 pytest-sugar==0.9.4       # via -r requirements.in
 pytest==6.0.2             # via -r requirements.in, pytest-cov, pytest-mock, pytest-sugar
-redis==3.5.3              # via -r requirements.in, fakeredis
+redis==3.5.3              # via fakeredis
 requests==2.24.0          # via codecov
 sentinels==1.0.0          # via mongomock
-six==1.15.0               # via fakeredis, mongomock, packaging, pip-tools, structlog
+six==1.15.0               # via fakeredis, mongomock, packaging, pip-tools
 sortedcontainers==2.2.2   # via fakeredis
-structlog==20.1.0         # via -r requirements.in, confluent-kafka-helpers
 termcolor==1.1.0          # via pytest-sugar
 testfixtures==6.14.2      # via flake8-isort
 toml==0.10.1              # via pytest
@@ -76,7 +66,6 @@ urllib3==1.25.10          # via requests
 wcwidth==0.2.5            # via prompt-toolkit
 wmctrl==0.3               # via pdbpp
 yapf==0.30.0              # via -r requirements.in
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-attrs==20.1.0             # via flake8-eradicate, pytest
+attrs==20.2.0             # via flake8-eradicate, pytest
 avro-python3==1.10.0      # via confluent-kafka-helpers
 backcall==0.2.0           # via ipython
 certifi==2020.6.20        # via requests
@@ -12,25 +12,25 @@ chardet==3.0.4            # via requests
 click==7.1.2              # via pip-tools
 cnamedtuple==0.1.6        # via -r requirements.in
 codecov==2.1.9            # via -r requirements.in
-confluent-kafka-helpers==0.7.6  # via -r requirements.in
-confluent-kafka==1.3.0    # via confluent-kafka-helpers
-coverage==5.2.1           # via codecov, pytest-cov
+confluent-kafka-helpers==0.7.7  # via -r requirements.in
+confluent-kafka==1.5.0    # via confluent-kafka-helpers
+coverage==5.3             # via codecov, pytest-cov
 decorator==4.4.2          # via ipython
 eradicate==1.0            # via flake8-eradicate
-fakeredis==0.9.0          # via -r requirements.in
+fakeredis==1.4.3          # via -r requirements.in
 fancycompleter==0.9.1     # via pdbpp
 fastavro==1.0.0.post1     # via confluent-kafka-helpers
 flake8-eradicate==0.4.0   # via -r requirements.in
 flake8-isort==4.0.0       # via -r requirements.in
 flake8==3.8.3             # via -r requirements.in, flake8-eradicate, flake8-isort
-hiredis==0.2.0            # via -r requirements.in
+hiredis==1.1.0            # via -r requirements.in
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via jsonpickle
 iniconfig==1.0.1          # via pytest
 ipdb==0.13.3              # via -r requirements.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.18.1           # via ipdb
-isort==5.4.2              # via -r requirements.in, flake8-isort
+isort==5.5.2              # via -r requirements.in, flake8-isort
 jedi==0.17.2              # via ipython
 jsonpickle==1.4.1         # via -r requirements.in
 mccabe==0.6.1             # via flake8
@@ -50,7 +50,7 @@ ptyprocess==0.6.0         # via pexpect
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
-pygments==2.6.1           # via ipython, pdbpp
+pygments==2.7.0           # via ipython, pdbpp
 pymongo==3.11.0           # via -r requirements.in
 pyparsing==2.4.7          # via packaging
 pyrepl==0.9.0             # via fancycompleter
@@ -59,16 +59,17 @@ pytest-cover==3.0.0       # via pytest-coverage
 pytest-coverage==0.0      # via -r requirements.in
 pytest-mock==3.3.1        # via -r requirements.in
 pytest-sugar==0.9.4       # via -r requirements.in
-pytest==6.0.1             # via -r requirements.in, pytest-cov, pytest-mock, pytest-sugar
-redis==2.10.6             # via -r requirements.in, fakeredis
+pytest==6.0.2             # via -r requirements.in, pytest-cov, pytest-mock, pytest-sugar
+redis==3.5.3              # via -r requirements.in, fakeredis
 requests==2.24.0          # via codecov
 sentinels==1.0.0          # via mongomock
-six==1.15.0               # via mongomock, packaging, pip-tools, structlog
+six==1.15.0               # via fakeredis, mongomock, packaging, pip-tools, structlog
+sortedcontainers==2.2.2   # via fakeredis
 structlog==20.1.0         # via -r requirements.in, confluent-kafka-helpers
 termcolor==1.1.0          # via pytest-sugar
-testfixtures==6.14.1      # via flake8-isort
+testfixtures==6.14.2      # via flake8-isort
 toml==0.10.1              # via pytest
-traitlets==5.0.0          # via ipython
+traitlets==5.0.4          # via ipython
 typed-ast==1.4.1          # via mypy
 typing-extensions==3.7.4.3  # via mypy
 urllib3==1.25.10          # via requests

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,3 +3,4 @@ set -e
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+pip install '.[mongo,redis,cnamedtuple]'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     author_email="support@fyndiq.com",
     license="MIT",
     packages=find_packages(),
-    setup_requires=['wheel'],
     install_requires=[
         'structlog>=17.2.0',
         'jsonpickle>=0.9.6',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="0.8.9",
+    version="0.8.10",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",
@@ -12,11 +12,11 @@ setup(
     setup_requires=['wheel'],
     install_requires=[
         'structlog>=17.2.0',
-        'jsonpickle==0.9.6',
-        'confluent-kafka-helpers==0.7.6'
+        'jsonpickle>=0.9.6',
+        'confluent-kafka-helpers>=0.7.6'
     ],
     extras_require={
-        'mongo': ["pymongo==3.6.1"],
+        'mongo': ["pymongo>=3.6.1"],
         'redis': ["redis>=2.10.6", "hiredis>=0.2.0"],
         'cnamedtuple': ["cnamedtuple>=0.1.6"]
     },

--- a/tests/messagebus/backends/mock/test_mock_backend.py
+++ b/tests/messagebus/backends/mock/test_mock_backend.py
@@ -9,10 +9,18 @@ class MockBackendTests:
     def setup_method(self):
         self.backend = MockBackend(config={})
 
-    @pytest.mark.parametrize('headers', [{'d': 'e'}, None])
-    def test_add_one_consumer_message_should_be_added_to_internal_queue(self, headers):
+    @pytest.mark.parametrize(
+        'headers, expected_headers',
+        [
+            ([('d', b'e')], {'d': 'e'}),
+            (None, {}),
+        ],
+    )
+    def test_add_one_consumer_message_should_be_added_to_internal_queue(
+        self, headers, expected_headers
+    ):
         self.backend.consumer.add_message(message_class='a', data={'b': 'c'}, headers=headers)
-        expected_message = dict(message_class='a', data={'b': 'c'}, headers=headers)
+        expected_message = dict(message_class='a', data={'b': 'c'}, headers=expected_headers)
         self.backend.consumer.assert_one_message_added_with(**expected_message)
 
     def test_consume_messages_should_call_handler(self):


### PR DESCRIPTION
## Changes
 - Bump `confluent_kafka_helpers` to 0.7.7
 - Don't pin required packages anymore. Mainly to not have to create a new tag everytime we want to bump `confluent_kafka_helpers`
 - Fix broken test