### PR TITLE
Add feature flag for sending metrics to datadog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: make lint
       - run:
           name: Running tests
-          command: make unit-test-ci
+          command: DATADOG_ENABLE_METRICS=1 make unit-test-ci
       - store_test_results:
           path: /tmp/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: make lint
       - run:
           name: Running tests
-          command: DATADOG_ENABLE_METRICS=1 make unit-test-ci
+          command: make unit-test-ci
       - store_test_results:
           path: /tmp/test-results
 

--- a/eventsourcing_helpers/command_handler.py
+++ b/eventsourcing_helpers/command_handler.py
@@ -153,7 +153,7 @@ class ESCommandHandler(CommandHandler):
                 self._handle_command(command, handler_inst=aggregate_root)
             except Exception as e:
                 self.repository.snapshot.delete(aggregate_root)
-                statsd.increment(
+                statsd.increment(  # type: ignore
                     'eventsourcing_helpers.snapshot.cache.delete', tags=[f'id={aggregate_root.id}']
                 )
                 raise e

--- a/eventsourcing_helpers/messagebus/backends/kafka/offset_watchdog/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/kafka/offset_watchdog/__init__.py
@@ -56,7 +56,7 @@ class OffsetWatchdog:
         seen = self.backend.seen(message)
         if seen:
             logger.warning("Message already seen previously", message_meta=message._meta)
-            statsd.increment(
+            statsd.increment(  # type: ignore
                 f'{base_metric}.messagebus.kafka.offset_watchdog.seen.count', tags=[
                     f'partition:{message._meta.partition}', f'topic:{message._meta.topic}',
                     f'consumer_group:{self.config["group.id"]}'  # type: ignore

--- a/eventsourcing_helpers/metrics.py
+++ b/eventsourcing_helpers/metrics.py
@@ -28,11 +28,12 @@ class TimedNullDecorator:
 
 
 try:
-    if getenv("DATADOG_ENABLE_METRICS") != "1":
-        raise UserWarning
-    import datadog
-    statsd = datadog.statsd
-except (ModuleNotFoundError, UserWarning):
+    if getenv('DATADOG_ENABLE_METRICS') != '1':
+        statsd = StatsdNullClient()  # type: ignore
+    else:
+        import datadog
+        statsd = datadog.statsd
+except ModuleNotFoundError:
     statsd = StatsdNullClient()  # type: ignore
 
 

--- a/eventsourcing_helpers/metrics.py
+++ b/eventsourcing_helpers/metrics.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from os import getenv
 
 base_metric = 'eventsourcing_helpers'
 
@@ -27,9 +28,11 @@ class TimedNullDecorator:
 
 
 try:
+    if getenv("DATADOG_ENABLE_METRICS") != "1":
+        raise UserWarning
     import datadog
     statsd = datadog.statsd
-except ModuleNotFoundError:
+except (ModuleNotFoundError, UserWarning):
     statsd = StatsdNullClient()  # type: ignore
 
 

--- a/eventsourcing_helpers/metrics.py
+++ b/eventsourcing_helpers/metrics.py
@@ -29,12 +29,12 @@ class TimedNullDecorator:
 
 try:
     if getenv('DATADOG_ENABLE_METRICS') != '1':
-        statsd = StatsdNullClient()  # type: ignore
+        statsd = StatsdNullClient()  # pragma: no cover; # type: ignore
     else:
-        import datadog
-        statsd = datadog.statsd
-except ModuleNotFoundError:
-    statsd = StatsdNullClient()  # type: ignore
+        import datadog  # pragma: no cover
+        statsd = datadog.statsd  # pragma: no cover; # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    statsd = StatsdNullClient()  # pragma: no cover; # type: ignore
 
 
 def call_counter(base_metric):

--- a/eventsourcing_helpers/repository/__init__.py
+++ b/eventsourcing_helpers/repository/__init__.py
@@ -71,7 +71,10 @@ class Repository:
                 self.backend.commit(id=id, events=events, **kwargs)
             except KafkaException as e:
                 logger.info("Kafka commit failed, rolling back snapshot!")
-                statsd.increment('eventsourcing_helpers.snapshot.cache.delete', tags=[f'id={id}'])
+                statsd.increment(  # type: ignore
+                    'eventsourcing_helpers.snapshot.cache.delete',
+                    tags=[f'id={id}']
+                )
                 self.snapshot.delete(aggregate_root)
                 raise e
 
@@ -97,7 +100,7 @@ class Repository:
             aggregate_root = self._load_from_event_storage(id, max_offset)
             logger.debug("Aggregate was loaded from event storage")
         else:
-            statsd.increment('eventsourcing_helpers.snapshot.cache.hits')
+            statsd.increment('eventsourcing_helpers.snapshot.cache.hits')  # type: ignore
             logger.debug("Aggregate was loaded from snapshot storage")
 
         return aggregate_root


### PR DESCRIPTION
Changes:
- Add feature flag environment variable `DATADOG_ENABLE_METRICS` that toggles sending metics to Datadog. Disable by default.