### PR TITLE
Bump version to 0.9.0, disable datadog metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="0.8.10",
+    version="0.9.0",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
Bump version to 0.9.0. The removal of the datadog metrics is something I would consider a minor version update as it does not break backwards compatibility but introduces a change that requires an action for the metrics to be sent.