### PR TITLE
Messagebus mock backend new assert method

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/mock/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/__init__.py
@@ -43,9 +43,12 @@ class Producer:
     def clear_messages(self) -> None:
         self.messages.clear()
 
+    def assert_message_produced_with(self, key: str, value: dict, **kwargs) -> None:
+        assert dict(key=key, value=value, **kwargs) in self.messages
+
     def assert_one_message_produced_with(self, key: str, value: dict, **kwargs) -> None:
         assert len(self.messages) == 1
-        assert dict(key=key, value=value, **kwargs) in self.messages
+        self.assert_message_produced_with(key=key, value=value, **kwargs)
 
     def assert_no_messages_produced(self) -> None:
         assert len(self.messages) == 0

--- a/tests/messagebus/backends/mock/test_mock_backend.py
+++ b/tests/messagebus/backends/mock/test_mock_backend.py
@@ -36,3 +36,9 @@ class MockBackendTests:
         self.backend.producer.assert_one_message_produced_with(
             **dict(value='b', key='a', headers=headers)
         )
+
+    def test_producer_assert_message_produced_with(self):
+        self.backend.produce(value='b', key='a')
+        self.backend.produce(value='c', key='b')
+        self.backend.producer.assert_message_produced_with(**dict(value='b', key='a'))
+        self.backend.producer.assert_message_produced_with(**dict(value='c', key='b'))


### PR DESCRIPTION
## Changes
 - Add new assert method `assert_message_produced_with` for messagebus mock backend