### PR TITLE
Assert multiple messages in Messagebus mock backend

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/mock/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/__init__.py
@@ -55,9 +55,7 @@ class Producer:
     def assert_multiple_messages_produced_with(self, messages: List) -> None:
         assert len(self.messages) == len(messages)
         for message in messages:
-            key = message.pop('key')
-            value = message.pop('value')
-            self.assert_message_produced_with(key=key, value=value, **message)
+            self.assert_message_produced_with(**message)
 
     def assert_no_messages_produced(self) -> None:
         assert len(self.messages) == 0

--- a/eventsourcing_helpers/messagebus/backends/mock/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/__init__.py
@@ -1,6 +1,6 @@
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Callable, Deque
+from typing import Callable, Deque, List
 
 import structlog
 
@@ -17,7 +17,9 @@ class Consumer:
     messages: Deque[Message] = field(default_factory=deque)
 
     def add_message(self, message_class: str, data: dict, headers: dict = None) -> None:
-        message = create_message(message_class=message_class, data=data, headers=headers)
+        message = create_message(
+            message_class=message_class, data=data, headers=headers
+        )
         self.messages.append(message)
 
     def get_messages(self) -> Deque[Message]:
@@ -49,6 +51,13 @@ class Producer:
     def assert_one_message_produced_with(self, key: str, value: dict, **kwargs) -> None:
         assert len(self.messages) == 1
         self.assert_message_produced_with(key=key, value=value, **kwargs)
+
+    def assert_multiple_messages_produced_with(self, messages: List) -> None:
+        assert len(self.messages) == len(messages)
+        for message in messages:
+            key = message.pop('key')
+            value = message.pop('value')
+            self.assert_message_produced_with(key=key, value=value, **message)
 
     def assert_no_messages_produced(self) -> None:
         assert len(self.messages) == 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,5 @@ use_parentheses=True
 known_confluent=confluent_kafka_helpers
 known_localfolder=eventsourcing_helpers
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,CONFLUENT,LOCALFOLDER
-not_skip=__init__.py
 virtual_env=.venv
 skip=.venv

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="0.8.11",
+    version="0.8.12",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",

--- a/tests/messagebus/backends/mock/test_mock_backend.py
+++ b/tests/messagebus/backends/mock/test_mock_backend.py
@@ -45,16 +45,37 @@ class MockBackendTests:
         self.backend.produce(key='b', value='c', headers=headers, topic='bar.foo')
 
         expected_messages = [
-            {'key': 'b', 'value': 'c', 'headers': headers, 'topic': 'bar.foo'},
             {'key': 'a', 'value': 'b', 'headers': headers, 'topic': 'foo.bar'},
+            {'key': 'b', 'value': 'c', 'headers': headers, 'topic': 'bar.foo'},
         ]
         self.backend.producer.assert_multiple_messages_produced_with(
             messages=expected_messages
         )
 
-        expected_messages.append(
-            {'key': 'b', 'value': 'c', 'headers': headers, 'topic': 'bar.foo'}
-        )
+    @pytest.mark.parametrize('headers', [{'d': 'e'}, None])
+    def test_producer_assert_multiple_messages_produced_with_invalid_length(self, headers):
+        self.backend.produce(key='a', value='b', headers=headers, topic='foo.bar')
+        self.backend.produce(key='b', value='c', headers=headers, topic='bar.foo')
+
+        expected_messages = [
+            {'key': 'b', 'value': 'c', 'headers': headers, 'topic': 'bar.foo'},
+            {'key': 'a', 'value': 'b', 'headers': headers, 'topic': 'foo.bar'},
+            {'key': 'd', 'value': 'e', 'headers': headers, 'topic': None},
+        ]
+        with pytest.raises(AssertionError):
+            self.backend.producer.assert_multiple_messages_produced_with(
+                messages=expected_messages
+            )
+
+    @pytest.mark.parametrize('headers', [{'d': 'e'}, None])
+    def test_producer_assert_multiple_messages_produced_with_invalid_message(self, headers):
+        self.backend.produce(key='a', value='b', headers=headers, topic='foo.bar')
+        self.backend.produce(key='b', value='c', headers=headers, topic='bar.foo')
+
+        expected_messages = [
+            {'key': 'a', 'value': 'b', 'headers': headers, 'topic': 'foo.bar'},
+            {'key': 'a', 'value': 'c', 'headers': headers, 'topic': 'bar.foo'},
+        ]
         with pytest.raises(AssertionError):
             self.backend.producer.assert_multiple_messages_produced_with(
                 messages=expected_messages


### PR DESCRIPTION
## Changes
 - Add new assert function `assert_multiple_messages_produced_with` to help writing cleaner tests to check if multiple messages were produced