### PR TITLE
feat(messagebus): add assert function assert_num_messages_produced

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/mock/backend.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/backend.py
@@ -44,6 +44,10 @@ class Consumer:
 class Producer:
     messages: Deque[dict] = field(default_factory=deque)
 
+    @property
+    def num_messages(self):
+        return len(self.messages)
+
     def add_message(self, message: dict) -> None:
         self.messages.append(message)
 
@@ -84,10 +88,13 @@ class Producer:
             self.assert_message_produced_with(**message)
 
     def assert_no_messages_produced(self) -> None:
-        assert len(self.messages) == 0
+        assert self.num_messages == 0
 
     def assert_one_message_produced(self) -> None:
-        assert len(self.messages) == 1
+        assert self.num_messages == 1
+
+    def assert_num_messages_produced(self, num: int) -> None:
+        assert self.num_messages == num
 
     def assert_messages_produced_with(self, messages: list) -> None:
         assert messages == list(self.messages)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="1.2.0",
+    version="1.3.0",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",

--- a/tests/messagebus/backends/mock/test_mock_backend.py
+++ b/tests/messagebus/backends/mock/test_mock_backend.py
@@ -92,3 +92,12 @@ class MockBackendTests:
         self.backend.produce(value="b", key="a")
         with pytest.raises(AssertionError):
             self.backend.producer.assert_one_message_produced()
+
+    def test_producer_assert_num_messages_produced(self):
+        self.backend.produce(value="b", key="a")
+        self.backend.producer.assert_num_messages_produced(num=1)
+
+        self.backend.produce(value="b", key="a")
+        self.backend.produce(value="b", key="a")
+        with pytest.raises(AssertionError):
+            self.backend.producer.assert_num_messages_produced(num=1)


### PR DESCRIPTION
## Background

Add some helper methods to make testing a bit cleaner.

## Changes

- Add property `num_messages`
- Add new assert method `assert_num_messages_produced`