### PR TITLE
feat(messagebus): add assert function assert_messages_produced_with_class_names

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/mock/backend.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/backend.py
@@ -99,6 +99,12 @@ class Producer:
     def assert_messages_produced_with(self, messages: list) -> None:
         assert messages == list(self.messages)
 
+    def assert_messages_produced_with_class_names(self, *class_names) -> None:
+        try:
+            assert class_names == tuple(m["value"]["class"] for m in self.messages)
+        except (TypeError, KeyError):
+            raise AssertionError("Invalid message envelope", self.messages)
+
 
 class MockBackend(MessageBusBackend):
     def __init__(self, config: dict) -> None:
@@ -110,7 +116,7 @@ class MockBackend(MessageBusBackend):
         value: dict,
         key: str = None,
         value_serializer: Callable = to_message_from_dto,
-        **kwargs
+        **kwargs,
     ) -> None:
         if isinstance(value, (Message, PydanticMixin)):
             value = value_serializer(value)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="1.3.0",
+    version="1.4.0",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",

--- a/tests/messagebus/backends/mock/test_mock_backend.py
+++ b/tests/messagebus/backends/mock/test_mock_backend.py
@@ -101,3 +101,17 @@ class MockBackendTests:
         self.backend.produce(value="b", key="a")
         with pytest.raises(AssertionError):
             self.backend.producer.assert_num_messages_produced(num=1)
+
+    def test_producer_assert_messages_produced_with_class_names(self):
+        self.backend.produce(value={"class": "a"}, key="a")
+        self.backend.produce(value={"class": "b"}, key="b")
+        self.backend.producer.assert_messages_produced_with_class_names("a", "b")
+
+        with pytest.raises(AssertionError):
+            self.backend.producer.assert_messages_produced_with_class_names("b", "a")
+
+        with pytest.raises(AssertionError) as exc:
+            self.backend.produce(value="c", key="c")
+            self.backend.producer.assert_messages_produced_with_class_names("a", "b", "c")
+
+        assert exc.value.args[0] == "Invalid message envelope"


### PR DESCRIPTION
## Changes

- Add new assert function `assert_messages_produced_with_class_names` which can be used when only the order of events are important without the data