### PR TITLE
fix: correctly distinguish between incoming and outgoing kafka messages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="1.4.0",
+    version="1.4.1",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
## Changes

- Correctly serialize "outgoing" messages (inherited via `from eventsourcing_helpers.message import Message`)