### PR TITLE
fix(message): make pydantic an optional dependency

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,42 @@
+# Migration guide
+
+## From 1.x -> 2.x
+
+### 1. Update `PydanticMixin` import
+
+If you are using the Pydantic mixin you have to change this import:
+
+From:
+
+	eventsourcing_helpers.message.PydanticMixin
+
+To:
+
+	eventsourcing_helpers.message.pydantic.PydanticMixin
+
+### 2. Update mock backend
+
+If you are using the "old" mock backend and add/assert messages like this:
+
+```python
+def test_create_article_stock(app, messagebus):
+    messagebus.consumer.add_message(
+        message_class="UpdateArticleStock", data={"id": "<article-id>"}
+    )
+    app.consume()
+
+    expected_event = events.ArticleStockUpdated(
+      id="<article-id>"
+    )
+    messagebus.producer.assert_message_produced_with(
+        key="<article-id>", value=expected_event
+    )
+```
+
+You will have to update the backend used in tests from:
+
+    eventsourcing_helpers.messagebus.backends.mock.MockBackend
+
+To:
+
+    eventsourcing_helpers.messagebus.backends.mock.backend_compat.MockBackend

--- a/eventsourcing_helpers/compat.py
+++ b/eventsourcing_helpers/compat.py
@@ -1,0 +1,30 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
+from typing import Any
+
+
+def get_dist_version(dist_name: str, module: Any | None = None, default: str = "0") -> str:
+    try:
+        return pkg_version(dist_name)
+    except PackageNotFoundError:
+        if module is not None:
+            return getattr(module, "__version__", default)
+        return default
+
+
+def parse_major(v: str) -> int:
+    nums = "".join(ch if ch.isdigit() or ch == "." else "." for ch in v).split(".")
+    try:
+        return int(nums[0] or 0)
+    except ValueError:
+        return 0
+
+
+def require_major_at_least(
+    dist_name: str, module: Any | None, required_major: int, feature_name: str
+) -> None:
+    v = get_dist_version(dist_name, module=module, default="0")
+    if parse_major(v) < required_major:
+        raise ImportError(
+            f"{feature_name} requires {dist_name}>={required_major}.0, but found {v!r}."
+        )

--- a/eventsourcing_helpers/message/__init__.py
+++ b/eventsourcing_helpers/message/__init__.py
@@ -1,0 +1,3 @@
+from .message import Command, Event, Message, NewMessage, OldMessage, message_factory
+
+__all__ = ["Event", "Command", "Message", "NewMessage", "OldMessage", "message_factory"]

--- a/eventsourcing_helpers/message/message.py
+++ b/eventsourcing_helpers/message/message.py
@@ -1,23 +1,10 @@
 import copy
 from typing import Callable
 
-from pydantic import BaseModel, ConfigDict
-
 try:
     from cnamedtuple import namedtuple
 except ImportError:
     from collections import namedtuple
-
-
-class PydanticMixin(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
-
-    @property
-    def _class(self):
-        return self.__class__.__name__
-
-    def to_dict(self):
-        return self.model_dump()
 
 
 class Message:

--- a/eventsourcing_helpers/message/pydantic.py
+++ b/eventsourcing_helpers/message/pydantic.py
@@ -1,0 +1,23 @@
+from eventsourcing_helpers.compat import require_major_at_least
+
+try:
+    import pydantic as _pyd
+    from pydantic import BaseModel, ConfigDict
+except ModuleNotFoundError as e:
+    raise ImportError(
+        "PydanticMixin is an optional feature. Install pydantic>=2 to use it "
+        "(e.g., `pip install 'pydantic>=2'` or enable the project's 'pydantic' extra)."
+    ) from e
+
+require_major_at_least("pydantic", module=_pyd, required_major=2, feature_name="PydanticMixin")
+
+
+class PydanticMixin(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    @property
+    def _class(self) -> str:
+        return self.__class__.__name__
+
+    def to_dict(self):
+        return self.model_dump()

--- a/eventsourcing_helpers/messagebus/__init__.py
+++ b/eventsourcing_helpers/messagebus/__init__.py
@@ -7,6 +7,7 @@ from eventsourcing_helpers.utils import import_backend
 BACKENDS = {
     "kafka_avro": "eventsourcing_helpers.messagebus.backends.kafka.KafkaAvroBackend",
     "mock": "eventsourcing_helpers.messagebus.backends.mock.backend.MockBackend",
+    "mock_compat": "eventsourcing_helpers.messagebus.backends.mock.backend_compat.MockBackend",
 }
 
 logger = structlog.get_logger(__name__)

--- a/eventsourcing_helpers/messagebus/backends/mock/backend.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/backend.py
@@ -6,7 +6,7 @@ from typing import Callable, Deque, Optional
 import structlog
 
 from eventsourcing_helpers.message import Message as MessageToKafka
-from eventsourcing_helpers.message import PydanticMixin
+from eventsourcing_helpers.message.pydantic import PydanticMixin
 from eventsourcing_helpers.messagebus.backends import MessageBusBackend
 from eventsourcing_helpers.messagebus.backends.mock.utils import create_message
 from eventsourcing_helpers.serializers import to_message_from_dto

--- a/eventsourcing_helpers/messagebus/backends/mock/backend_compat.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/backend_compat.py
@@ -1,0 +1,91 @@
+import copy
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, List, Union
+from unittest.mock import MagicMock
+
+import structlog
+
+from eventsourcing_helpers.messagebus.backends import MessageBusBackend
+
+from confluent_kafka_helpers.message import Message
+
+logger = structlog.get_logger(__name__)
+
+
+def create_message(message_class: str, data: dict, headers: Union[None, dict]) -> Message:
+    kafka_message = MagicMock()
+    kafka_message.configure_mock(
+        **{
+            "value.return_value": {"class": message_class, "data": copy.deepcopy(data)},
+            "timestamp.return_value": (0, time.time()),
+            "headers.return_value": headers,
+        }
+    )
+    message = Message(kafka_message=kafka_message)
+    return message
+
+
+@dataclass
+class Consumer:
+    messages: Deque[Message] = field(default_factory=deque)
+
+    def add_message(self, message_class: str, data: dict, headers: dict = None) -> None:
+        message = create_message(message_class=message_class, data=data, headers=headers)
+        self.messages.append(message)
+
+    def get_messages(self) -> Deque[Message]:
+        return self.messages
+
+    def assert_one_message_added_with(
+        self, message_class: str, data: dict, headers: dict = None
+    ) -> None:
+        if headers is None:
+            headers = {}
+        assert len(self.messages) == 1
+        assert {"class": message_class, "data": data} == self.messages[0].value
+        assert headers == self.messages[0]._meta.headers
+
+
+@dataclass
+class Producer:
+    messages: Deque[dict] = field(default_factory=deque)
+
+    def add_message(self, message: dict) -> None:
+        self.messages.append(message)
+
+    def clear_messages(self) -> None:
+        self.messages.clear()
+
+    def assert_message_produced_with(self, key: str, value: dict, **kwargs) -> None:
+        assert dict(key=key, value=value, **kwargs) in self.messages
+
+    def assert_one_message_produced_with(self, key: str, value: dict, **kwargs) -> None:
+        assert len(self.messages) == 1
+        self.assert_message_produced_with(key=key, value=value, **kwargs)
+
+    def assert_multiple_messages_produced_with(self, messages: List) -> None:
+        assert len(self.messages) == len(messages)
+        for message in messages:
+            self.assert_message_produced_with(**message)
+
+    def assert_no_messages_produced(self) -> None:
+        assert len(self.messages) == 0
+
+    def assert_one_message_produced(self) -> None:
+        assert len(self.messages) == 1
+
+
+class MockBackend(MessageBusBackend):
+    def __init__(self, config: dict) -> None:
+        self.consumer = Consumer()
+        self.producer = Producer()
+
+    def produce(self, value: dict, key: str = None, **kwargs) -> None:
+        self.producer.add_message(dict(value=value, key=key, **kwargs))
+
+    def consume(self, handler: Callable) -> None:
+        messages = self.consumer.get_messages()
+        while messages:
+            handler(messages.popleft())

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,6 @@ mongomock
 mypy
 pdbpp
 pip-tools
-pydantic
 pytest
 pytest-coverage
 pytest-mock

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,4 +3,4 @@ set -e
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-pip install -e '.[mongo,redis,cnamedtuple]'
+pip install -e '.[mongo,redis,cnamedtuple,pydantic]'

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,4 @@ ignore_missing_imports = True
 show_error_context = True
 pretty = True
 implicit_optional = True
+plugins = pydantic.mypy

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="1.4.2",
+    version="2.0.0",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",
@@ -16,12 +16,12 @@ setup(
         "structlog>=17.2.0",
         "jsonpickle>=0.9.6",
         "confluent-kafka-helpers>=1.0.0",
-        "pydantic>=2.0",
     ],
     extras_require={
         "mongo": ["pymongo>=3.6.1"],
         "redis": ["redis>=2.10.6", "hiredis>=0.2.0"],
         "cnamedtuple": ["cnamedtuple>=0.1.6"],
+        "pydantic": ["pydantic>=2"],
     },
     zip_safe=False,
 )

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -3,11 +3,11 @@ from typing import NamedTuple
 import pytest
 from pydantic import ValidationError
 
-from eventsourcing_helpers.message import Message, PydanticMixin, message_factory
+from eventsourcing_helpers.message import Message, message_factory
+from eventsourcing_helpers.message.pydantic import PydanticMixin
 
 
 class MessageTests:
-
     def setup_method(self):
         self.data = {"id": 1, "foo": "bar", "baz": None, "foobar": {"a": "b"}}
         fields = [(k, None) for k in self.data.keys()]


### PR DESCRIPTION
## Background

To make it easier to update this lib in services using older Pydantic versions (<2) lets make `pydantic` optional and only require it when actually trying to import the `PydanticMixin` (not many services use it currently).

This will make it easier to roll out the new "header propagation" introduced here: https://github.com/fyndiq/confluent_kafka_helpers/pull/89

## Changes

- Make `pydantic` an optional dependency and only require it if actually importing `PydanticMixin`
- Revert the "old" mock backend to make upgrades easier. The backend is backward compatible with the old interface used when adding/asserting messages. The only change required is changing the backend from `eventsourcing_helpers.messagebus.backends.mock.MockBackend` to `eventsourcing_helpers.messagebus.backends.mock.backend_compat.MockBackend`