### PR TITLE
feat(event_handler): add support for custom DTO deserializers

### DIFF
--- a/eventsourcing_helpers/event_handler.py
+++ b/eventsourcing_helpers/event_handler.py
@@ -15,6 +15,30 @@ class EventHandler(Handler):
     Application service that calls the correct domain handler for an event.
     """
 
+    def _find_handler(self, event_class: str) -> tuple:
+        """
+        Find the handler associated for a given `event_class`.
+
+        The handler key can be either a string or a class.
+
+        Args:
+            event_class: The event class name to find a handler for.
+
+        Returns:
+            Found handler function and optional message deserializer class.
+        """
+        if event_class in self.handlers:
+            return self.handlers[event_class], None
+
+        for key in self.handlers.keys():
+            try:
+                if key.__name__ == event_class:
+                    return self.handlers[key], key
+            except AttributeError:
+                pass
+
+        return None, None
+
     def _can_handle_command(self, message: Message) -> bool:
         """
         Checks if the event is something we can handle.
@@ -26,7 +50,9 @@ class EventHandler(Handler):
             bool: Flag to indicate if we can handle the event.
         """
         event_class = message.value["class"]
-        if event_class not in self.handlers:
+        handler, _ = self._find_handler(event_class)
+
+        if handler is None:
             logger.debug("Unhandled event", event_class=event_class)
             return False
 
@@ -44,7 +70,8 @@ class EventHandler(Handler):
 
         event_class = message.value["class"]
         logger.info("Handling event", event_class=event_class)
-        handler = self.handlers[event_class]
+
+        handler, deserialize_class = self._find_handler(event_class)
         handler_name = get_callable_representation(handler)
 
         # this is the first span from the applications perspective and will will act as the "service
@@ -61,7 +88,7 @@ class EventHandler(Handler):
                 service_name=service_name,
                 system=None,
             ):
-                event = self.message_deserializer(message)
+                event = self.message_deserializer(message, deserialize_class=deserialize_class)
 
             span.set_attribute(
                 attrs.MESSAGING_OPERATION_TYPE,
@@ -71,7 +98,7 @@ class EventHandler(Handler):
                 "eventsourcing_helpers.handler.handle",
                 tags=[
                     "message_type:event",
-                    f"message_class:{event._class}",
+                    f"message_class:{event_class}",
                     f"handler:{handler_name}",
                 ],
             )(handler)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="2.1.0",
+    version="2.2.0",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
# Background

Currently, in the event handler (also the command handler), it's only possible to map events to a handler function by a string name. For example:

```python
from eventsourcing_helpers.message import Message


def article_does_not_exist(message: Message) -> None:
    controller(message)


class EventHandler(event_handler.EventHandler):
    handlers = {
        "ArticleDoesNotExist": article_does_not_exist,
    }
```

The `message` parameter is, by default, a dynamically created namedtuple which acts as a simple DTO but provides no type information about the data inside, making it difficult to understand the message contents. Developers currently need to manually transform this `message` into a typed object like this to get typing information):

```python
@dataclasses.dataclass
def ArticleDoesNotExist:
    id: str
    error: str


def article_does_not_exist(message: Message) -> None:
    event = ArticleDoesNotExist(**message.to_dict())
    controller(event)
```

This PR implements this transformation automatically within the event handler.

With this change, developers can now define handlers using class-based typing (can be any class, regular python class, pydantic etc):

```python
@dataclasses.dataclass
def ArticleDoesNotExist:
    id: str
    error: str


def article_does_not_exist(event: ArticleDoesNotExist) -> None:
    controller(event)


class EventHandler(event_handler.EventHandler):
    handlers = {
        ArticleDoesNotExist: article_does_not_exist,  # <-- note that the key is not a string but a class
    }
```

Instead of receiving an untyped object, handlers now receive properly typed objects of the specified class. This approach is similar to how web frameworks like FastAPI work, where schemas are defined for each endpoint.

**NOTE!** This is only adding support in the event handler, similar changes will be added to the command handler later when needed.

## Changes

- Add support for using deserializing classes as keys when defining handlers, complementing the existing string-based approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add support for class keys in `EventHandler.handlers` and pass custom `deserialize_class` through deserialization; update serializers, tests, and bump version.
> 
> - **Event handling**:
>   - Add `_find_handler` to resolve handlers by string or class key in `EventHandler`.
>   - Update `_can_handle_command` and `handle` to use `_find_handler` and pass `deserialize_class` to `message_deserializer`.
>   - Metrics tag now uses original `event_class` instead of `event._class`.
> - **Serialization**:
>   - Enhance `from_message_to_dto` to accept `deserialize_class`; when provided, instantiate that class with `Meta` and data; otherwise build namedtuple including `Meta` (field order adjusted).
>   - Add minimal typing hints and return type flexibility.
> - **Tests**:
>   - Add tests for class-key handler resolution and custom deserialization.
>   - Adjust existing tests for field order and handler resolution; extend tracing assertions.
> - **Version**:
>   - Bump `setup.py` version to `2.2.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89a24e5d4e8d780dee37af2b2a317d017542a96f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->