### PR TITLE
Allow extra fields to PydanticMixin

### DIFF
--- a/eventsourcing_helpers/message/pydantic.py
+++ b/eventsourcing_helpers/message/pydantic.py
@@ -13,7 +13,7 @@ require_major_at_least("pydantic", module=_pyd, required_major=2, feature_name="
 
 
 class PydanticMixin(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="ignore")
 
     @property
     def _class(self) -> str:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="2.0.0",
+    version="2.1.0",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -70,20 +70,19 @@ class MessageTests:
         foobar["a"] = "c"
         assert self.message.foobar["a"] == "b"
 
+class Foobar(PydanticMixin):
+    a: str
+
+class FooEvent(PydanticMixin):
+    id: int
+    foo: str
+    baz: str | None
+    foobar: Foobar
 
 class PydanticMixinTests:
+
     def setup_method(self):
         self.data = {"id": 1, "foo": "bar", "baz": None, "foobar": {"a": "b"}}
-
-        class Foobar(PydanticMixin):
-            a: str
-
-        class FooEvent(PydanticMixin):
-            id: int
-            foo: str
-            baz: str | None
-            foobar: Foobar
-
         self.message = FooEvent(**self.data)
 
     def test_to_dict(self):
@@ -95,3 +94,8 @@ class PydanticMixinTests:
     def test_read_only(self):
         with pytest.raises(ValidationError):
             self.message.id = 2
+
+    def test_extra_fields_ignored(self):
+        data_with_extra = {**self.data, "extra": "ignored"}
+        message = FooEvent(**data_with_extra)
+        assert "extra" not in message.to_dict()


### PR DESCRIPTION
This enables us to: 
1. Not fully type the entire message. In many services we don't type all fields, instead we just type what we use in that service. 
2. Gradually add more fields to a message without immediately breaking all consumers using the PydanticMixin when the producer is updated with the new fields

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> PydanticMixin now ignores extra fields; tests updated accordingly and package version bumped to 2.1.0.
> 
> - **Pydantic**:
>   - Change `PydanticMixin.model_config` from `extra="forbid"` to `extra="ignore"` to allow unmodeled fields.
> - **Tests**:
>   - Promote `Foobar` and `FooEvent` test models to module scope.
>   - Add `test_extra_fields_ignored` verifying extra fields are dropped in `FooEvent`.
> - **Packaging**:
>   - Bump `setup.py` version from `2.0.0` to `2.1.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6955856210ff83d61de13fa50b6e35090248b349. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->