### PR TITLE
fix(messagebus): support adding dict headers to mock backend

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/mock/utils.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/utils.py
@@ -1,12 +1,16 @@
 import copy
 import time
-from typing import Optional
+from typing import Optional, Union
 from unittest.mock import MagicMock
 
 from confluent_kafka_helpers.message import Message
 
 
-def create_message(key: str, value: dict, topic: Optional[str], headers: Optional[dict]) -> Message:
+def create_message(
+    key: str, value: dict, topic: Optional[str], headers: Optional[Union[dict, list]]
+) -> Message:
+    if isinstance(headers, dict):
+        headers = list(headers.items())
     kafka_message = MagicMock()
     kafka_message.configure_mock(
         **{

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="2.2.0",
+    version="2.2.1",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",

--- a/tests/messagebus/backends/mock/test_mock_backend.py
+++ b/tests/messagebus/backends/mock/test_mock_backend.py
@@ -15,6 +15,7 @@ class MockBackendTests:
         "headers, expected_headers",
         [
             ([("d", b"e")], {"d": "e"}),
+            ({"d": "e"}, {"d": "e"}),
             (None, {}),
         ],
     )


### PR DESCRIPTION
## Background

The mock backend currently accepts message headers only as a tuple, which is inconsistent because headers are produced as a dictionary. This change enables the mock backend to accept headers as either a dictionary or a list of tuples, improving usability for message bus testing.

## Changes

- Implemented dictionary-to-tuple conversion: Headers provided as a dictionary are now automatically converted to a list of tuples, the format required for Kafka messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable mock messagebus to accept headers as dict or list of tuples, with conversion applied; bump package to 2.2.1.
> 
> - **Messagebus Mock Utils (`eventsourcing_helpers/messagebus/backends/mock/utils.py`)**:
>   - `create_message` now accepts `headers` as `Optional[Union[dict, list]]` and converts dict headers to a list of tuples.
> - **Tests (`tests/messagebus/backends/mock/test_mock_backend.py`)**:
>   - Extend parameterized cases to cover dict-form headers in consumer assertions.
> - **Packaging (`setup.py`)**:
>   - Version bump from `2.2.0` to `2.2.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97eafd4462ac0d90832f8906cf7e866402845fe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->