### PR TITLE
test(messagebus): add support for controlling eof behaviour

### DIFF
--- a/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
+++ b/eventsourcing_helpers/messagebus/backends/kafka/__init__.py
@@ -73,7 +73,7 @@ class KafkaAvroBackend(MessageBusBackend):
                 consumer.commit(asynchronous=False)
             except KafkaException as e:
                 error_code = e.args[0].code()
-                if error_code == KafkaError._NO_OFFSET:
+                if error_code == KafkaError._NO_OFFSET:  # type: ignore[attr-defined]
                     logger.warning("Offset already committed")
                 else:
                     raise

--- a/eventsourcing_helpers/messagebus/backends/mock/backend.py
+++ b/eventsourcing_helpers/messagebus/backends/mock/backend.py
@@ -1,3 +1,4 @@
+import time
 import warnings
 from collections import deque
 from dataclasses import dataclass, field
@@ -117,6 +118,7 @@ class MockBackend(MessageBusBackend):
     def __init__(self, config: dict) -> None:
         self.consumer = Consumer()
         self.producer = Producer()
+        self.config = config
 
     def produce(
         self,
@@ -130,6 +132,12 @@ class MockBackend(MessageBusBackend):
         self.producer.add_message(dict(value=value, key=key, **kwargs))
 
     def consume(self, handler: Callable) -> None:
+        stop_on_eof = self.config["consumer"].get("stop_on_eof", True)
         messages = self.consumer.get_messages()
-        while messages:
-            handler(messages.popleft())
+        while True:
+            if messages:
+                handler(messages.popleft())
+            elif stop_on_eof:
+                break
+            else:
+                time.sleep(0.1)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="eventsourcing-helpers",
-    version="2.2.1",
+    version="2.3.0",
     description="Helpers for practicing the Event sourcing pattern",
     url="https://github.com/fyndiq/eventsourcing_helpers",
     author="Fyndiq AB",

--- a/tests/messagebus/backends/mock/test_mock_backend.py
+++ b/tests/messagebus/backends/mock/test_mock_backend.py
@@ -1,3 +1,4 @@
+import threading
 from typing import NamedTuple
 from unittest.mock import Mock
 
@@ -9,7 +10,7 @@ from eventsourcing_helpers.messagebus.backends.mock.backend import MockBackend
 
 class MockBackendTests:
     def setup_method(self):
-        self.backend = MockBackend(config={})
+        self.backend = MockBackend(config={"consumer": {}})
 
     @pytest.mark.parametrize(
         "headers, expected_headers",
@@ -36,6 +37,20 @@ class MockBackendTests:
         handler = Mock()
         self.backend.consume(handler=handler)
         assert handler.call_count == 2
+
+    def test_consume_with_stop_on_eof_disabled_should_continue_when_no_messages(self):
+        backend = MockBackend(config={"consumer": {"stop_on_eof": False}})
+        handler = Mock()
+
+        def consume_in_thread():
+            backend.consume(handler=handler)
+
+        thread = threading.Thread(target=consume_in_thread, daemon=True)
+        thread.start()
+        thread.join(timeout=0.3)
+
+        assert thread.is_alive()
+        assert handler.call_count == 0
 
     @pytest.mark.parametrize("headers", [{"d": "e"}, None])
     def test_produced_assert_one_message_produced_with(self, headers):

--- a/tests/test_kafka_backend_compat.py
+++ b/tests/test_kafka_backend_compat.py
@@ -17,12 +17,8 @@ class MockBackendTests:
         ],
     )
     def test_consumer_assert_one_message_added_with(self, headers, expected_headers):
-        self.backend.consumer.add_message(
-            message_class="a", data={"b": "c"}, headers=headers
-        )
-        expected_message = dict(
-            message_class="a", data={"b": "c"}, headers=expected_headers
-        )
+        self.backend.consumer.add_message(message_class="a", data={"b": "c"}, headers=headers)
+        expected_message = dict(message_class="a", data={"b": "c"}, headers=expected_headers)
         self.backend.consumer.assert_one_message_added_with(**expected_message)
 
     def test_consume_messages_should_call_handler(self):
@@ -48,14 +44,10 @@ class MockBackendTests:
             {"key": "a", "value": "b", "headers": headers, "topic": "foo.bar"},
             {"key": "b", "value": "c", "headers": headers, "topic": "bar.foo"},
         ]
-        self.backend.producer.assert_multiple_messages_produced_with(
-            messages=expected_messages
-        )
+        self.backend.producer.assert_multiple_messages_produced_with(messages=expected_messages)
 
     @pytest.mark.parametrize("headers", [{"d": "e"}, None])
-    def test_producer_assert_multiple_messages_produced_with_invalid_length(
-        self, headers
-    ):
+    def test_producer_assert_multiple_messages_produced_with_invalid_length(self, headers):
         self.backend.produce(key="a", value="b", headers=headers, topic="foo.bar")
         self.backend.produce(key="b", value="c", headers=headers, topic="bar.foo")
 
@@ -65,14 +57,10 @@ class MockBackendTests:
             {"key": "d", "value": "e", "headers": headers, "topic": None},
         ]
         with pytest.raises(AssertionError):
-            self.backend.producer.assert_multiple_messages_produced_with(
-                messages=expected_messages
-            )
+            self.backend.producer.assert_multiple_messages_produced_with(messages=expected_messages)
 
     @pytest.mark.parametrize("headers", [{"d": "e"}, None])
-    def test_producer_assert_multiple_messages_produced_with_invalid_message(
-        self, headers
-    ):
+    def test_producer_assert_multiple_messages_produced_with_invalid_message(self, headers):
         self.backend.produce(key="a", value="b", headers=headers, topic="foo.bar")
         self.backend.produce(key="b", value="c", headers=headers, topic="bar.foo")
 
@@ -81,9 +69,7 @@ class MockBackendTests:
             {"key": "a", "value": "c", "headers": headers, "topic": "bar.foo"},
         ]
         with pytest.raises(AssertionError):
-            self.backend.producer.assert_multiple_messages_produced_with(
-                messages=expected_messages
-            )
+            self.backend.producer.assert_multiple_messages_produced_with(messages=expected_messages)
 
     def test_producer_assert_message_produced_with(self):
         self.backend.produce(value="b", key="a")

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -70,14 +70,17 @@ class MessageTests:
         foobar["a"] = "c"
         assert self.message.foobar["a"] == "b"
 
+
 class Foobar(PydanticMixin):
     a: str
+
 
 class FooEvent(PydanticMixin):
     id: int
     foo: str
     baz: str | None
     foobar: Foobar
+
 
 class PydanticMixinTests:
 


### PR DESCRIPTION
## Summary

Adds support for controlling EOF (reaching end-of-file for a partition) behavior in the mock message bus backend to enable testing of application shutdown behavior without requiring pre-populated messages.

## Background

When testing applications that use the eventsourcing_helpers library, it's necessary to run the mocked consume loop in a background thread to properly test graceful shutdown behavior. Previously, the mock backend would immediately exit when no messages were available, making it impossible to test scenarios where the application needs to handle shutdown signals while the consumer is running.

This change enables testing of graceful shutdown patterns as demonstrated in [article-status-projection-service#33](https://github.com/fyndiq/article-status-projection-service/pull/33), where the application needs to properly close database connections and other resources when receiving shutdown signals.

The `stop_on_eof` configuration option already exists in [`confluent_kafka_helpers`](https://github.com/fyndiq/confluent_kafka_helpers/blob/master/confluent_kafka_helpers/consumer.py#L23) for this exact purpose. This implementation leverages the existing configuration to provide consistent behavior between the real Kafka backend and the mock backend.

## Changes

- Refactored `consume()` method to support `stop_on_eof` configuration option:
  - When `stop_on_eof=True` (default): Exits immediately when no messages are available (preserves existing behavior)
  - When `stop_on_eof=False`: Continues running indefinitely with 0.1s sleep intervals, allowing the consume loop to run in a thread until interrupted

## Backward compatibility

This change is fully backward compatible. The default behavior (`stop_on_eof=True`) preserves the existing functionality where the consume loop exits immediately when no messages are available.
