### PR TITLE
Add Claude Code GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,10 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    uses: fyndiq/.github/.github/workflows/claude-code-review-reusable.yml@master
+    secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,16 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    uses: fyndiq/.github/.github/workflows/claude-reusable.yml@master
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflow files that enable Claude Code on this repo:

- **`claude.yml`** — Interactive `@claude` mentions in issues, PRs, and review comments
- **`claude-code-review.yml`** — Automatic code review on new/updated PRs

Both are thin caller files (~8-13 lines) that invoke centralized reusable workflows from [`fyndiq/.github`](https://github.com/fyndiq/.github). All logic (action versions, prompts, permissions) is maintained centrally — these files only define event triggers and should never need updating.

### Prerequisites (org-level, already configured)
- `ANTHROPIC_API_KEY` organization secret
- Claude GitHub App installed org-wide

### How it works
- Comment `@claude` on any issue or PR to interact with Claude
- PRs automatically get a code review from Claude when opened or updated